### PR TITLE
Fix unnesting with RangedSummarizedExperiment objects

### DIFF
--- a/R/tidyr_methods.R
+++ b/R/tidyr_methods.R
@@ -52,85 +52,109 @@
 #' @export
 NULL
 
-
 #' @importFrom rlang quo_name
 #' @importFrom purrr imap
 #'
 #' @export
+
 unnest.tidySummarizedExperiment_nested <-
-    function(data, cols, ..., keep_empty=FALSE, ptype=NULL, names_sep=NULL, names_repair="check_unique", .drop, .id, .sep, .preserve) {
-
-
+  function(data, cols, ..., keep_empty=FALSE, ptype=NULL, names_sep=NULL, names_repair="check_unique", .drop, .id, .sep, .preserve) {
+    
+    
     # Need this otherwise crashes map
     .data_ <- data
-
+    
     cols <- enquo(cols)
-
-
-
-    .data_ %>%
-        when(
-
-            # If my only column to unnest is tidySummarizedExperiment
-            pull(., !!cols) %>%
-                .[[1]] %>%
-                class() %>%
-                as.character() %>% 
-                eq("SummarizedExperiment") %>%
-                any() ~ {
-
-                  se = pull(., !!cols) %>% .[[1]] 
-                  
-                  # Mark if columns belong to feature or sample
-                  my_unnested_tibble =
-                    mutate(., !!cols := map(!!cols, ~ as_tibble(.x))) %>%
-                    select(-suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                    unnest(!!cols)
-
-                  # Get which column is relative to feature or sample
-                  sample_columns = my_unnested_tibble %>% get_subset_columns(!!s_(se)$symbol)
-                  transcript_columns = my_unnested_tibble %>% get_subset_columns(!!f_(se)$symbol)
-                  source_column =
-                    c(
-                      rep(s_(se)$name, length(sample_columns)) %>% setNames(sample_columns),
-                      rep(f_(se)$name, length(transcript_columns)) %>% setNames(transcript_columns)
-                    )
-
-                  # Do my trick to unnest
-                  mutate(., !!cols := imap(
-                    !!cols, ~ .x %>%
-                      bind_cols_internal(
-
-                        # Attach back the columns used for nesting
-                        .data_ %>%
-                          select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                          slice(rep(.y, ncol(.x) * nrow(.x))),
-
-                        # Column sample-wise or feature-wise
-                        column_belonging =
-                          source_column[
-                            .data_ %>%
-                              select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                              colnames()
-                          ]
-                      )
-                  )) %>%
-                    pull(!!cols) %>%
-
-                    # See if split by feature or sample
-                    when(
-                      is_split_by_sample(.) & is_split_by_transcript(.) ~ stop("tidySummarizedExperiment says: for the moment nesting both by sample- and feature-wise information is not possible. Please ask this feature to github/stemangiola/tidySummarizedExperiment"),
-                      ~ reduce(., bind_rows)
-                    )
-                },
-
-            # Else do normal stuff
-            ~ (.) %>%
-                drop_class("tidySummarizedExperiment_nested") %>%
-                tidyr::unnest(!!cols, ..., keep_empty=keep_empty, ptype=ptype, names_sep=names_sep, names_repair=names_repair) %>%
-                add_class("tidySummarizedExperiment_nested")
+    
+    # If the column is not SE do normal stuff
+    if(
+      data %>% 
+      pull(!!cols) %>%
+      .[[1]] %>%
+      class() %>%
+      as.character() %in% 
+      c("SummarizedExperiment", "RangedSummarizedExperiment") %>%
+      all() %>% 
+      not()
+    )
+      return(
+        data %>%
+          drop_class("tidySummarizedExperiment_nested") %>%
+          tidyr::unnest(!!cols, ..., keep_empty=keep_empty, ptype=ptype, names_sep=names_sep, names_repair=names_repair) %>%
+          add_class("tidySummarizedExperiment_nested")
+      )
+    
+    # If both nested by transcript and sample
+    if( s_(se)$name %in% colnames(data) & f_(se)$name %in% colnames(data) ){
+      stop("tidySummarizedExperiment says: for the moment nesting both by sample- and feature-wise information is not possible. Please ask this feature to github/stemangiola/tidySummarizedExperiment")
+    }
+    
+    # If both nested not by transcript nor sample
+    if(! s_(se)$name  %in% colnames(data) & !f_(se)$name %in% colnames(data) ){
+      
+      se = pull(data, !!cols) %>% .[[1]] 
+      
+      # Mark if columns belong to feature or sample
+      my_unnested_tibble =
+        mutate(data, !!cols := map(!!cols, ~ as_tibble(.x))) %>%
+        select(-suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+        unnest(!!cols)
+      
+      # Get which column is relative to feature or sample
+      sample_columns = my_unnested_tibble %>% get_subset_columns(!!s_(se)$symbol)
+      transcript_columns = my_unnested_tibble %>% get_subset_columns(!!f_(se)$symbol)
+      
+      source_column =
+        c(
+          rep(s_(se)$name, length(sample_columns)) %>% setNames(sample_columns),
+          rep(f_(se)$name, length(transcript_columns)) %>% setNames(transcript_columns)
         )
-}
+      
+      # Do my trick to unnest
+      return(
+        mutate(data, !!cols := imap(
+          !!cols, ~ .x %>%
+            bind_cols_internal(
+              
+              # Attach back the columns used for nesting
+              .data_ %>%
+                select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+                slice(rep(.y, ncol(.x) * nrow(.x))),
+              
+              # Column sample-wise or feature-wise
+              column_belonging =
+                source_column[
+                  .data_ %>%
+                    select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+                    colnames()
+                ]
+            )
+        )) %>%
+          pull(!!cols) %>% 
+          reduce(bind_rows)
+      )
+      
+    }
+    
+    # If column is SE nd only feature
+    if(f_(se)$name %in% colnames(data)){
+      
+      se = do.call(SummarizedExperiment::rbind, pull(data, !!cols))
+      rowData(se) = cbind( rowData(se), data %>% select(-!!cols, -!!f_(se)$symbol))
+      
+      return(se)
+    }
+    
+    # If column is SE nd only sample
+    if(s_(se)$name %in% colnames(data)){
+      
+      se = do.call(SummarizedExperiment::cbind, pull(data, !!cols))
+      colData(se) = cbind( colData(se), data %>% select(-!!cols, -!!s_(se)$symbol))
+      
+      return(se)
+      
+    }
+  }
 
 #' nest
 #'


### PR DESCRIPTION
Hello, this pull request fixes the error when unnesting `RangedSummarizedExperiment` objects. As Mike mentioned, a working version of `unnest()` was included in the branch `adapt_to_rangedSE`. 

The only change required was adding a check for `RangedSummarizedExperiment` objects, but the function in `adapt_to_rangedSE` was also significantly faster, so I copied across the whole thing.  

This is working well with the airway data from https://bioconductor.org/packages/release/data/experiment/html/airway.html, but let me know if there are any further issues with different data sets.