### PR TITLE
Unnesting with RangedSummarizedExperiment objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: tidySummarizedExperiment
 Title: Brings SummarizedExperiment to the Tidyverse 
-Version: 1.9.5
+Version: 1.9.6
 Authors@R: c(person("Stefano", "Mangiola", email = "mangiolastefano@gmail.com",
                   role = c("aut", "cre")) )
 Description: tidySummarizedExperiment is an adapter that abstracts the 'SummarizedExperiment' container 

--- a/R/tidyr_methods.R
+++ b/R/tidyr_methods.R
@@ -52,85 +52,109 @@
 #' @export
 NULL
 
-
 #' @importFrom rlang quo_name
 #' @importFrom purrr imap
 #'
 #' @export
+
 unnest.tidySummarizedExperiment_nested <-
-    function(data, cols, ..., keep_empty=FALSE, ptype=NULL, names_sep=NULL, names_repair="check_unique", .drop, .id, .sep, .preserve) {
-
-
+  function(data, cols, ..., keep_empty=FALSE, ptype=NULL, names_sep=NULL, names_repair="check_unique", .drop, .id, .sep, .preserve) {
+    
+    
     # Need this otherwise crashes map
     .data_ <- data
-
+    
     cols <- enquo(cols)
-
-
-
-    .data_ %>%
-        when(
-
-            # If my only column to unnest is tidySummarizedExperiment
-            pull(., !!cols) %>%
-                .[[1]] %>%
-                class() %>%
-                as.character() %>% 
-                eq("SummarizedExperiment") %>%
-                any() ~ {
-
-                  se = pull(., !!cols) %>% .[[1]] 
-                  
-                  # Mark if columns belong to feature or sample
-                  my_unnested_tibble =
-                    mutate(., !!cols := map(!!cols, ~ as_tibble(.x))) %>%
-                    select(-suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                    unnest(!!cols)
-
-                  # Get which column is relative to feature or sample
-                  sample_columns = my_unnested_tibble %>% get_subset_columns(!!s_(se)$symbol)
-                  transcript_columns = my_unnested_tibble %>% get_subset_columns(!!f_(se)$symbol)
-                  source_column =
-                    c(
-                      rep(s_(se)$name, length(sample_columns)) %>% setNames(sample_columns),
-                      rep(f_(se)$name, length(transcript_columns)) %>% setNames(transcript_columns)
-                    )
-
-                  # Do my trick to unnest
-                  mutate(., !!cols := imap(
-                    !!cols, ~ .x %>%
-                      bind_cols_internal(
-
-                        # Attach back the columns used for nesting
-                        .data_ %>%
-                          select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                          slice(rep(.y, ncol(.x) * nrow(.x))),
-
-                        # Column sample-wise or feature-wise
-                        column_belonging =
-                          source_column[
-                            .data_ %>%
-                              select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
-                              colnames()
-                          ]
-                      )
-                  )) %>%
-                    pull(!!cols) %>%
-
-                    # See if split by feature or sample
-                    when(
-                      is_split_by_sample(.) & is_split_by_transcript(.) ~ stop("tidySummarizedExperiment says: for the moment nesting both by sample- and feature-wise information is not possible. Please ask this feature to github/stemangiola/tidySummarizedExperiment"),
-                      ~ reduce(., bind_rows)
-                    )
-                },
-
-            # Else do normal stuff
-            ~ (.) %>%
-                drop_class("tidySummarizedExperiment_nested") %>%
-                tidyr::unnest(!!cols, ..., keep_empty=keep_empty, ptype=ptype, names_sep=names_sep, names_repair=names_repair) %>%
-                add_class("tidySummarizedExperiment_nested")
+    
+    # If the column is not SE do normal stuff
+    if(
+      data %>% 
+      pull(!!cols) %>%
+      .[[1]] %>%
+      class() %>%
+      as.character() %in% 
+      c("SummarizedExperiment", "RangedSummarizedExperiment") %>%
+      all() %>% 
+      not()
+    )
+      return(
+        data %>%
+          drop_class("tidySummarizedExperiment_nested") %>%
+          tidyr::unnest(!!cols, ..., keep_empty=keep_empty, ptype=ptype, names_sep=names_sep, names_repair=names_repair) %>%
+          add_class("tidySummarizedExperiment_nested")
+      )
+    
+    # If both nested by transcript and sample
+    if( s_(se)$name %in% colnames(data) & f_(se)$name %in% colnames(data) ){
+      stop("tidySummarizedExperiment says: for the moment nesting both by sample- and feature-wise information is not possible. Please ask this feature to github/stemangiola/tidySummarizedExperiment")
+    }
+    
+    # If both nested not by transcript nor sample
+    if(! s_(se)$name  %in% colnames(data) & !f_(se)$name %in% colnames(data) ){
+      
+      se = pull(data, !!cols) %>% .[[1]] 
+      
+      # Mark if columns belong to feature or sample
+      my_unnested_tibble =
+        mutate(data, !!cols := map(!!cols, ~ as_tibble(.x))) %>%
+        select(-suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+        unnest(!!cols)
+      
+      # Get which column is relative to feature or sample
+      sample_columns = my_unnested_tibble %>% get_subset_columns(!!s_(se)$symbol)
+      transcript_columns = my_unnested_tibble %>% get_subset_columns(!!f_(se)$symbol)
+      
+      source_column =
+        c(
+          rep(s_(se)$name, length(sample_columns)) %>% setNames(sample_columns),
+          rep(f_(se)$name, length(transcript_columns)) %>% setNames(transcript_columns)
         )
-}
+      
+      # Do my trick to unnest
+      return(
+        mutate(data, !!cols := imap(
+          !!cols, ~ .x %>%
+            bind_cols_internal(
+              
+              # Attach back the columns used for nesting
+              .data_ %>%
+                select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+                slice(rep(.y, ncol(.x) * nrow(.x))),
+              
+              # Column sample-wise or feature-wise
+              column_belonging =
+                source_column[
+                  .data_ %>%
+                    select(-!!cols, -suppressWarnings( one_of(s_(se)$name, f_(se)$name))) %>%
+                    colnames()
+                ]
+            )
+        )) %>%
+          pull(!!cols) %>% 
+          reduce(bind_rows)
+      )
+      
+    }
+    
+    # If column is SE nd only feature
+    if(f_(se)$name %in% colnames(data)){
+      
+      se = do.call(SummarizedExperiment::rbind, pull(data, !!cols))
+      rowData(se) = cbind( rowData(se), data %>% select(-!!cols, -!!f_(se)$symbol))
+      
+      return(se)
+    }
+    
+    # If column is SE nd only sample
+    if(s_(se)$name %in% colnames(data)){
+      
+      se = do.call(SummarizedExperiment::cbind, pull(data, !!cols))
+      colData(se) = cbind( colData(se), data %>% select(-!!cols, -!!s_(se)$symbol))
+      
+      return(se)
+      
+    }
+  }
 
 #' nest
 #'

--- a/tests/testthat/test-tidyr_methods.R
+++ b/tests/testthat/test-tidyr_methods.R
@@ -8,6 +8,33 @@ tt <-
     
     tidySummarizedExperiment::mutate(col2 = "other_col")
 
+# Create SummarizedExperiment object for testing
+nrows <- 200
+ncols <- 6
+counts <- matrix(runif(nrows * ncols, 1, 1e4), nrows)
+rowRanges <- GRanges(rep(c("chr1", "chr2"), c(50, 150)),
+                     IRanges(floor(runif(200, 1e5, 1e6)), width=100),
+                     strand=sample(c("+", "-"), 200, TRUE),
+                     feature_id=sprintf("ID%03d", 1:200))
+colData <- DataFrame(Treatment=rep(c("ChIP", "Input"), 3),
+                     row.names=LETTERS[1:6])
+rse <- SummarizedExperiment(assays=SimpleList(counts=counts),
+                            rowRanges=rowRanges, colData=colData)
+rownames(rse) <- sprintf("ID%03d", 1:200)
+
+test_that("RangedSummarizedExperiment_nest_unnest", {
+  tryCatch({
+    rse_nested <- rse %>%
+      nest(data = -.sample)
+
+    rse_unnested <- rse_nested %>%
+      unnest(data)
+  })
+  
+  expect_equal(rse@colData, rse_unnested@colData)
+  expect_equal(rse@rowRanges, rse_unnested@rowRanges)
+})
+
 test_that("nest_unnest", {
 
     y <- tibble::tibble(


### PR DESCRIPTION
This pull request fixes an error when unnesting RangedSummarizedExperiment objects, and adds a unit test for nesting and unnesting RangedSummarizedExperiment objects.

I have added both commits contained within this pull request to commit `879a0c6`. Hopefully this will allow you to merge around my previous commit `d4938a9` and keep everything organised, but let me know if I need to do anything differently on my end.