### PR TITLE
Bugfix nonmatching dimnames

### DIFF
--- a/R/dplyr_methods.R
+++ b/R/dplyr_methods.R
@@ -1417,7 +1417,7 @@ pull.SummarizedExperiment <- function(.data, var=-1, name=NULL, ...) {
         warning( 
           "tidySummarizedExperiment says: the assays in your SummarizedExperiment have column names, 
   but their order is not the same. Pulling assays can return data in a order you don't expect. 
-  To avoid unwanted behaviour it is highly reccomended to have assays with the same order of colnames and rownames" 
+  To avoid unwanted behaviour it is highly recommended to have assays with the same order of colnames and rownames" 
         )
         
         # reorder assay colnames before printing

--- a/R/tibble_methods.R
+++ b/R/tibble_methods.R
@@ -88,8 +88,8 @@ as_tibble.SummarizedExperiment <- function(x, ...,
     
     # If I want to return all columns
     count_info %>%
-      inner_join(sample_info, by=s_(x)$name) %>%
-      inner_join(gene_info, by=f_(x)$name) %>%
+      full_join(sample_info, by=s_(x)$name) %>%
+      full_join(gene_info, by=f_(x)$name) %>%
       when(nrow(range_info) > 0 ~ (.) %>% left_join(range_info) %>% suppressMessages(), ~ (.)) 
     
   # This function outputs a tibble after subsetting the columns

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -9,7 +9,7 @@
 #' @noRd
 #'
 #' @return A tibble with an additional attribute
-drop_attr = function(var, name) {
+drop_attr <- function(var, name) {
     attr(var, name) <- NULL
     var
 }
@@ -25,12 +25,12 @@ drop_attr = function(var, name) {
 #' @noRd
 #' 
 #' @return A tibble with an additional attribute
-drop_all_attr = function(var) {
+drop_all_attr <- function(var) {
     
-  N = var %>% attributes() %>% names()
+    N <- var %>% attributes() %>% names()
     
     for (n in N) {
-    var = var %>% drop_attr(n)
+        var <- var %>% drop_attr(n)
     }
     
     var
@@ -57,10 +57,10 @@ drop_all_attr = function(var) {
 as_matrix <- function(tbl,
                       rownames = NULL,
                       do_check = TRUE) {
-  rownames = enquo(rownames)
-  tbl %>%
+    rownames <- enquo(rownames)
     
-    # Through warning if data frame is not numerical beside the rownames column (if present)
+    tbl %>%
+        # Throw warning if data frame is not numerical beside the rownames column (if present)
         when(
             do_check &&
                 (.) %>%
@@ -139,6 +139,7 @@ prepend <- function(x, values, before = 1) {
         c(x[seq_len(before - 1)], values, x[before:n])
     }
 }
+
 #' Add class to abject
 #'
 #'
@@ -151,8 +152,9 @@ prepend <- function(x, values, before = 1) {
 #' 
 #' @noRd
 add_class <- function(var, name) {
-    if (!name %in% class(var)) class(var) <- prepend(class(var), name)
-
+    if (!name %in% class(var)) {
+        class(var) <- prepend(class(var), name)
+    }
     var
 }
 
@@ -199,9 +201,9 @@ get_abundance_sc_wide <- function(.data, transcripts = NULL, all = FALSE) {
 
     # Check if output would be too big without forcing
     if (
-        length(variable_feature) == 0 &
-            is.null(transcripts) &
-            all == FALSE
+        length(variable_feature) == 0 &&
+            is.null(transcripts) &&
+            !all
     ) {
         stop("
                 Your object does not contain variable feature labels,
@@ -215,13 +217,12 @@ get_abundance_sc_wide <- function(.data, transcripts = NULL, all = FALSE) {
 
     # Get variable features if existing
     if (
-        length(variable_feature) > 0 &
-            is.null(transcripts) &
-            all == FALSE
+        length(variable_feature) > 0 &&
+            is.null(transcripts) &&
+            !all
     ) {
         variable_genes <- variable_feature
-    } # Else
-    else {
+    } else {
         variable_genes <- NULL
     }
     
@@ -260,7 +261,8 @@ get_abundance_sc_wide <- function(.data, transcripts = NULL, all = FALSE) {
 #'
 #'
 #' @noRd
-get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_zeros=FALSE) {
+get_abundance_sc_long <- function(.data, transcripts = NULL, all = FALSE,
+                                  exclude_zeros = FALSE) {
 
     # Solve CRAN warnings
     . <- NULL
@@ -270,9 +272,9 @@ get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_ze
 
     # Check if output would be too big without forcing
     if (
-        length(variable_feature) == 0 &
-            is.null(transcripts) &
-            all == FALSE
+        length(variable_feature) == 0 &&
+            is.null(transcripts) &&
+            !all
     ) {
         stop("
                 Your object does not contain variable feature labels,
@@ -287,13 +289,12 @@ get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_ze
 
     # Get variable features if existing
     if (
-        length(variable_feature) > 0 &
-            is.null(transcripts) &
-            all == FALSE
+        length(variable_feature) > 0 &&
+            is.null(transcripts) &&
+            !all
     ) {
         variable_genes <- variable_feature
-    } # Else
-    else {
+    } else {
         variable_genes <- NULL
     }
     
@@ -375,13 +376,12 @@ update_SE_from_tibble <- function(.data_mutated, se, column_belonging = NULL) {
         # where a unique value cannot be linked to sample or feature
         c(names(column_belonging[column_belonging == f_(se)$name]))
     
-    secial_columns = get_special_columns(
-      
+    secial_columns <- get_special_columns(
         # Decrease the size of the dataset
         se[1:min(100, nrow(se)), 1:min(20, ncol(se))]
     ) 
     
-    new_colnames_col = 
+    new_colnames_col <- 
         .data_mutated %>%
         select_if(!colnames(.) %in% setdiff(colnames_col, s_(se)$name)) %>% 
         
@@ -438,7 +438,7 @@ update_SE_from_tibble <- function(.data_mutated, se, column_belonging = NULL) {
     
     # This to avoid the mismatch between missing row names for counts 
     # and numerical row names for rowData
-    row_names_row = 
+    row_names_row <- 
         row_data %>%
         rownames() %>%
         when(
@@ -480,8 +480,6 @@ update_SE_from_tibble <- function(.data_mutated, se, column_belonging = NULL) {
                         .x = 
                             .x %>%
                             spread(!!s_(se)$symbol, value) %>% 
-            
-                  
                             as_matrix(rownames = !!f_(se)$symbol)  %>% 
                             suppressWarnings()
                         
@@ -519,23 +517,23 @@ slice_optimised <- function(.data, ..., .preserve=FALSE) {
         .data %>%
         
         # Subset the object for samples and features present in the simulated data
-    .[rownames(.) %in% simulated_slice[,f_(.)$name], colnames(.) %in% simulated_slice[,s_(.)$name]] %>% 
+        .[rownames(.) %in% simulated_slice[,f_(.)$name], 
+          colnames(.) %in% simulated_slice[,s_(.)$name]] %>% 
         inner_join(simulated_slice, by = c(f_(.)$name, s_(.)$name)) 
     
     # If order do not match with the one proposed by slice convert to tibble
     if (.data %>% is("tbl") %>% not()) {
-    .data_for_match = .data %>%  select(!!f_(.data)$symbol, !!s_(.data)$symbol) %>% as_tibble() 
+        .data_for_match <- .data %>% select(!!f_(.data)$symbol, !!s_(.data)$symbol) %>% as_tibble() 
         
-    x = c(pull(.data_for_match, !!f_(.data)$symbol), pull(.data_for_match, !!s_(.data)$symbol))
-    y =  c(pull(simulated_slice, !!f_(.data)$symbol), pull(simulated_slice, !!s_(.data)$symbol))
+        x <- c(pull(.data_for_match, !!f_(.data)$symbol), pull(.data_for_match, !!s_(.data)$symbol))
+        y <- c(pull(simulated_slice, !!f_(.data)$symbol), pull(simulated_slice, !!s_(.data)$symbol))
         
-    if( identical(x, y) %>% not())
+        if (identical(x, y) %>% not()) {
             left_join(simulated_slice, as_tibble(.data), by = c(f_(.data)$name, s_(.data)$name))
-    else
+        } else {
             .data
         }
-  
- 
+    }
 }
 
 
@@ -594,7 +592,9 @@ get_special_datasets <- function(se) {
             is(., "CompressedGRangesList") ~ {
                 
                 # If GRanges does not have row names
-        if(is.null(rr@partitioning@NAMES)) rr@partitioning@NAMES = as.character(1:nrow(se))
+                if (is.null(rr@partitioning@NAMES)) {
+                    rr@partitioning@NAMES <- as.character(1:nrow(se))
+                }
                 
                 tibble::as_tibble(rr) %>%
                     eliminate_GRanges_metadata_columns_also_present_in_Rowdata(se) %>%
@@ -701,7 +701,7 @@ get_count_datasets <- function(se) {
             # This might happen because the user loaded tidySummarizedExperiment and is 
             # print a SingleCellExperiment
             if (is(.x, "dgCMatrix") | is(.x, "DelayedArray")) {
-        .x = as.matrix(.x) 
+                .x <- as.matrix(.x) 
             }
             
             # Rearrange if assays has colnames and rownames
@@ -743,7 +743,7 @@ get_count_datasets <- function(se) {
         ) %>% 
         
         # Add dummy sample or feature if we have empty assay. 
-    # This is needed for a correct isualisation of the tibble form
+        # This is needed for a correct visualisation of the tibble form
         when(
             f_(se)$name %in% colnames(.) %>% not ~ mutate(., !!f_(se)$symbol := as.character(NA)),
             s_(se)$name %in% colnames(.) %>% not ~ mutate(., !!s_(se)$symbol := as.character(NA)),
@@ -801,7 +801,6 @@ outersect <- function(x, y) {
 #' @noRd
 get_subset_columns <- function(.data, .col) {
     
-
     # Comply with CRAN NOTES
     . <- NULL
     
@@ -838,35 +837,33 @@ get_subset_columns <- function(.data, .col) {
 
 #' @importFrom purrr map_int
 #' @importFrom purrr map
-is_split_by_transcript = function(.my_data){
+is_split_by_transcript <- function(.my_data) {
     
-  se = .my_data[[1]]
-    tot_length = .my_data %>% map(~ pull(.x, !!f_(se)$symbol) ) %>% unlist %>% unique() %>% length
-    all_lengths = .my_data %>% map_int(~ pull(.x, !!f_(se)$symbol) %>% unique() %>% length) 
-    
-    all_lengths %>% unique %>% length() %>% gt(1) |
-        (all_lengths != tot_length) %>% any()
-    
-}
-
-is_split_by_sample = function(.my_data){
-    
-    se = .my_data[[1]]
-    tot_length = .my_data %>% map(~ pull(.x, !!s_(se)$symbol) ) %>% unlist %>% unique() %>% length
-    all_lengths = .my_data %>% map_int(~ pull(.x, !!s_(se)$symbol) %>% unique() %>% length) 
+    se <- .my_data[[1]]
+    tot_length <- .my_data %>% map(~ pull(.x, !!f_(se)$symbol) ) %>% unlist %>% unique() %>% length
+    all_lengths <- .my_data %>% map_int(~ pull(.x, !!f_(se)$symbol) %>% unique() %>% length) 
     
     all_lengths %>% unique %>% length() %>% gt(1) |
         (all_lengths != tot_length) %>% any()
+}
+
+is_split_by_sample <- function(.my_data) {
     
+    se <- .my_data[[1]]
+    tot_length <- .my_data %>% map(~ pull(.x, !!s_(se)$symbol) ) %>% unlist %>% unique() %>% length
+    all_lengths <- .my_data %>% map_int(~ pull(.x, !!s_(se)$symbol) %>% unique() %>% length) 
+    
+    all_lengths %>% unique %>% length() %>% gt(1) |
+        (all_lengths != tot_length) %>% any()
 }
 
 
-get_GRanges_colnames = function(){
+get_GRanges_colnames <- function() {
     "GenomicRanges"
 }
 
 
-eliminate_GRanges_metadata_columns_also_present_in_Rowdata = function(.my_data, se){
+eliminate_GRanges_metadata_columns_also_present_in_Rowdata <- function(.my_data, se) {
     .my_data %>%
         select(-one_of(colnames(rowData(se)))) %>%
         
@@ -874,12 +871,12 @@ eliminate_GRanges_metadata_columns_also_present_in_Rowdata = function(.my_data, 
         suppressWarnings() 
 }
 
-subset_tibble_output = function(.data, count_info, sample_info, gene_info, range_info, .subset){
+subset_tibble_output <- function(.data, count_info, sample_info, gene_info, range_info, .subset) {
     # This function outputs a tibble after subsetting the columns
-  .subset = enquo(.subset)
+    .subset <- enquo(.subset)
     
     # Build template of the output
-  output_colnames = 
+    output_colnames <- 
         slice(count_info, 0) %>%
         left_join(slice(sample_info, 0), by = s_(.data)$name) %>%
         left_join(slice(gene_info, 0), by = f_(.data)$name) %>%
@@ -889,7 +886,7 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
     
     
     # Sample table
-  sample_info = 
+    sample_info <- 
         sample_info %>%
         when(
             colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
@@ -898,7 +895,7 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
         )
     
     # Ranges table
-  range_info = 
+    range_info <- 
         range_info %>%
         when(
             colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
@@ -907,7 +904,7 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
         )
     
     # Ranges table
-  gene_info = 
+    gene_info <- 
         gene_info %>%
         when(
             colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
@@ -916,7 +913,7 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
         )
     
   # Ranges table
-  count_info = 
+    count_info <- 
         count_info %>%
         when(
             colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
@@ -924,27 +921,25 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
                 suppressWarnings()
         )
   
-  
     if (
         !is.null(count_info) & 
         (
             !is.null(sample_info) & !is.null(gene_info) | 
             
             # Make exception for weirs cases (e.g. c(sample, counts))
-      (colnames(count_info) %>% outersect(c(f_(.data)$name, s_(.data)$name)) %>% length() %>% gt(0))
+            (colnames(count_info) %>% outersect(c(f_(.data)$name, s_(.data)$name)) %>% 
+             length() %>% gt(0))
         )
     ) {
-    output_df = 
+        output_df <- 
             count_info %>%
             when(!is.null(sample_info) ~ (.) %>% left_join(sample_info, by=s_(.data)$name), ~ (.)) %>%
             when(!is.null(gene_info) ~ (.) %>% left_join(gene_info, by=f_(.data)$name), ~ (.)) %>%
             when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
-  }
-  else if(!is.null(sample_info) ){
-    output_df = sample_info
-  }
-  else if(!is.null(gene_info)){
-    output_df = gene_info %>%
+    } else if (!is.null(sample_info) ) {
+        output_df <- sample_info
+    } else if (!is.null(gene_info)) {
+        output_df <- gene_info %>%
             
             # If present join GRanges
             when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
@@ -955,11 +950,10 @@ subset_tibble_output = function(.data, count_info, sample_info, gene_info, range
         # Cleanup
         select(one_of(output_colnames)) %>%
         suppressWarnings()
-  
 }
 
 #' @importFrom stringr str_replace
-change_reserved_column_names = function(col_data, .data ){
+change_reserved_column_names <- function(col_data, .data) {
     
     # Fix  NOTEs
     . = NULL
@@ -975,28 +969,28 @@ change_reserved_column_names = function(col_data, .data ){
     
 }
 
-choose_name_if_present = function(x){
-  columns_query = c()
+choose_name_if_present <- function(x) {
+    columns_query <- c()
     for (i in 1:length(x)) {
-    if(is.null(names(x[i]))) columns_query[i] = x[i]
-    else columns_query[i] = names(x[i])
+        if (is.null(names(x[i]))) columns_query[i] <- x[i]
+        else columns_query[i] <- names(x[i])
     }
     
     columns_query
 }
 
 #' @importFrom purrr when
-join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"), join_function, force_tibble_route = FALSE,
+join_efficient_for_SE <- function(x, y, by = NULL, copy = FALSE, 
+                                  suffix = c(".x", ".y"), join_function, 
+                                  force_tibble_route = FALSE,
                                   ...) {
     
-  
-   
     # Comply to CRAN notes 
     . <- NULL 
     
     # Deprecation of special column names
     if (is_sample_feature_deprecated_used(x, when(by, !is.null(.) ~ by, ~ colnames(y)))) {
-    x= ping_old_special_column_into_metadata(x)
+        x <- ping_old_special_column_into_metadata(x)
     }
     
     # Get the colnames of samples and feature datasets
@@ -1004,13 +998,12 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
     colnames_row <- get_rownames_col(x)
     
     # See if join done by sample, feature or both
-  columns_query = by %>% when(
+    columns_query <- by %>% when(
         !is.null(.) ~ choose_name_if_present(.), 
         ~ colnames(y) %>% intersect(c(colnames_col, colnames_row))
     )
     
     if (
-    
         # Complex join that it is not efficient yet
         (any(columns_query %in% colnames_row) & any(columns_query %in% colnames_col)) |
         
@@ -1021,8 +1014,6 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
         # Needed for internal recurrence if outcome is not valid
         force_tibble_route) {
         
-    
-    
         # If I have a big dataset
         if (ncol(x) > 100) message("tidySummarizedExperiment says: if you are joining a dataframe both sample-wise and feature-wise, for efficiency (until further development), it is better to separate your joins and join datasets sample-wise OR feature-wise.")
         
@@ -1047,7 +1038,7 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
     # Join only feature-wise
     else if (any(columns_query %in% colnames_row) & !any(columns_query %in% colnames_col)) {
         
-    row_data_tibble = 
+        row_data_tibble <-  
             rowData(x) %>% 
             as_tibble(rownames = f_(x)$name) %>%  
             join_function(y, by = by, copy = copy, suffix = suffix, ...) 
@@ -1057,19 +1048,20 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
             is.na(pull(row_data_tibble, !!f_(x)$symbol)) %>% any | 
             duplicated(pull(row_data_tibble, !!f_(x)$symbol)) %>% any |
             pull(row_data_tibble, !!f_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
-    ) return(join_efficient_for_SE(x, y, by=by, copy=copy, suffix=suffix, join_function, force_tibble_route = TRUE, ...))
+        ) return(join_efficient_for_SE(x, y, by = by, copy = copy, suffix = suffix, 
+                                       join_function, force_tibble_route = TRUE, ...))
         
-    row_data = 
+        row_data <- 
             row_data_tibble %>% 
             data.frame(row.names = pull(., !!f_(x)$symbol)) %>%
             select(-!!f_(x)$symbol) %>%
             DataFrame()
         
         # Subset in case of an inner join, or a right join
-    x = x[rownames(row_data),]  
+        x <- x[rownames(row_data),]  
         
         # Tranfer annotation
-    rowData(x) = row_data
+        rowData(x) <- row_data
         
         # Return
         x
@@ -1078,7 +1070,7 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
     # Join only sample-wise
     else if (any(columns_query %in% colnames_col) & !any(columns_query %in% colnames_row)) {
         
-    col_data_tibble = 
+        col_data_tibble <- 
             colData(x) %>% 
             as_tibble(rownames = s_(x)$name) %>%  
             join_function(y, by = by, copy = copy, suffix = suffix, ...)
@@ -1088,131 +1080,124 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
             is.na(pull(col_data_tibble, !!s_(x)$symbol)) %>% any | 
             duplicated(pull(col_data_tibble, !!s_(x)$symbol)) %>% any |
             pull(col_data_tibble, !!s_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
-    ) return(join_efficient_for_SE(x, y, by=by, copy=copy, suffix=suffix, join_function, force_tibble_route = TRUE, ...))
+        ) return(join_efficient_for_SE(x, y, by = by, copy = copy, suffix = suffix, 
+                                       join_function, force_tibble_route = TRUE, ...))
     
-    col_data = 
+        col_data <- 
             col_data_tibble %>% 
             data.frame(row.names = pull(., !!s_(x)$symbol)) %>%
             select(-!!s_(x)$symbol) %>%
             DataFrame()
         
-    
         # Subset in case of an inner join, or a right join
-    x = x[,rownames(col_data)]  
+        x <- x[,rownames(col_data)]  
         
-    # Tranfer annotation
-    colData(x) = col_data
+        # Transfer annotation
+        colData(x) <- col_data
         
         # Return
         x
     }
     
     else stop("tidySummarizedExperiment says: ERROR FOR DEVELOPERS: this option should not exist. In join utility.")
-  
-  
-  
 }
 
-get_ellipse_colnames = function(...){
-  
+get_ellipse_colnames <- function(...) {
     (enquos(..., .ignore_empty = "all") %>% map(~ quo_name(.x)) %>% unlist)
 }
 
-get_colnames_col = function(x){
+get_colnames_col <- function(x) {
     colnames(colData(x)) %>% 
         c(s_(x)$name) 
 }
 
-get_rownames_col = function(x){
+get_rownames_col <- function(x) {
     x %>%
         when(
             .hasSlot(., "rowData") | .hasSlot(., "elementMetadata") ~ colnames(rowData(.)), 
             TRUE ~ c()
         ) %>% 
         c(f_(x)$name) 
-
 }
 
 # This function is used for the change of special sample column to .sample
 # Check if "sample" is included in the query and is not part of any other existing annotation
 #' @importFrom stringr str_detect
 #' @importFrom stringr regex
-is_sample_feature_deprecated_used = function(.data, user_columns, use_old_special_names = FALSE){
+is_sample_feature_deprecated_used <- function(.data, user_columns, use_old_special_names = FALSE) {
   
-  old_standard_is_used_for_sample =  
+    old_standard_is_used_for_sample <- 
         (
-      ( any(str_detect(user_columns  , regex("\\bsample\\b"))) & !any(str_detect(user_columns  , regex("\\W*(\\.sample)\\W*")))  ) |
+            ( any(str_detect(user_columns, regex("\\bsample\\b"))) & 
+                  !any(str_detect(user_columns, regex("\\W*(\\.sample)\\W*")))  ) |
                 "sample" %in% user_columns 
         ) & 
         !"sample" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
   
-  old_standard_is_used_for_feature = 
+    old_standard_is_used_for_feature <- 
         (
-      ( any(str_detect(user_columns  , regex("\\bfeature\\b"))) & !any(str_detect(user_columns  , regex("\\W*(\\.feature)\\W*")))  ) |
+            ( any(str_detect(user_columns, regex("\\bfeature\\b"))) & 
+                  !any(str_detect(user_columns, regex("\\W*(\\.feature)\\W*")))  ) |
                 "feature" %in% user_columns 
         ) & 
         !"feature" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
   
-  old_standard_is_used = old_standard_is_used_for_sample | old_standard_is_used_for_feature
+    old_standard_is_used <- old_standard_is_used_for_sample | old_standard_is_used_for_feature
   
     if (old_standard_is_used) {
         warning("tidySummarizedExperiment says: from version 1.3.1, the special columns including sample/feature id (colnames(se), rownames(se)) has changed to \".sample\" and \".feature\". This dataset is returned with the old-style vocabulary (feature and sample), however we suggest to update your workflow to reflect the new vocabulary (.feature, .sample)")
     
-    use_old_special_names = TRUE
+        use_old_special_names <- TRUE
     }
     
     use_old_special_names
 }
   
-data_frame_returned_message = "tidySummarizedExperiment says: A data frame is returned for independent data analysis."
-duplicated_cell_names = "tidySummarizedExperiment says: This operation lead to duplicated feature names. A data frame is returned for independent data analysis."
+data_frame_returned_message <- "tidySummarizedExperiment says: A data frame is returned for independent data analysis."
+duplicated_cell_names <- "tidySummarizedExperiment says: This operation lead to duplicated feature names. A data frame is returned for independent data analysis."
 
 # Key column names
 #' @importFrom S4Vectors metadata
 #' @importFrom S4Vectors metadata<-
-ping_old_special_column_into_metadata = function(.data){
+ping_old_special_column_into_metadata <- function(.data) {
     
-  metadata(.data)$feature__ = get_special_column_name_symbol("feature")
-  metadata(.data)$sample__ = get_special_column_name_symbol("sample")
+    metadata(.data)$feature__ <- get_special_column_name_symbol("feature")
+    metadata(.data)$sample__ <- get_special_column_name_symbol("sample")
     
     .data
 }
 
-get_special_column_name_symbol = function(name){
+get_special_column_name_symbol <- function(name) {
     list(name = name, symbol = as.symbol(name))
 }
 
 # This function produce artificially the feature ans sample column, 
 # to make optimisation before as_tibble is called
 # for big datasets
-simulate_feature_sample_from_tibble = function(.data){
-  
-  r = rownames(.data) %>% .[rep(1:length(.), ncol(.data) )]
-  c = colnames(.data) %>% .[rep(1:length(.), each=nrow(.data) )]
+simulate_feature_sample_from_tibble <- function(.data) {
+    r <- rownames(.data) %>% .[rep(1:length(.), ncol(.data) )]
+    c <- colnames(.data) %>% .[rep(1:length(.), each = nrow(.data) )]
     
     tibble(!!f_(.data)$symbol := r,  !!s_(.data)$symbol := c)
-  
 }
 
-
-
-feature__ =  get_special_column_name_symbol(".feature")
-sample__ = get_special_column_name_symbol(".sample")
+feature__ <- get_special_column_name_symbol(".feature")
+sample__ <- get_special_column_name_symbol(".sample")
 
 #' @importFrom S4Vectors metadata
-f_ =  function(x){
+f_ <- function(x) {
     # Check if old deprecated columns are used
     if ("feature__" %in% names(metadata(x))) feature__ = metadata(x)$feature__
     return(feature__)
 }
 
 #' @importFrom S4Vectors metadata
-s_ = function(x){
+s_ <- function(x) {
     if ("sample__" %in% names(metadata(x))) sample__ = metadata(x)$sample__
     return(sample__)
 }
 
-split_SummarizedExperiment_by_feature_to_list = function(.data){
+split_SummarizedExperiment_by_feature_to_list <- function(.data) {
     if (nrow(.data) > 1000)
         message("tidySummarizedExperiment says: grouping a SummarizedExperiment by feature takes 1 minute for ~ 10,000 features.")
     map(1:nrow(.data), ~ .data[.x,])
@@ -1229,12 +1214,12 @@ split_SummarizedExperiment_by_feature_to_list = function(.data){
 #' @param name A character name of the attribute
 #'
 #' @return A tibble with an additional attribute
-add_attr = function(var, attribute, name) {
+add_attr <- function(var, attribute, name) {
     attr(var, name) <- attribute
     var
 }
 
-is_filer_columns_in_column_selection = function(.data, ...){
+is_filer_columns_in_column_selection <- function(.data, ...) {
     # columns = enquos(columns)
     tryCatch({
         .data |>
@@ -1245,7 +1230,7 @@ is_filer_columns_in_column_selection = function(.data, ...){
     error = function(e) FALSE)
 }
 
-check_if_assays_are_NOT_consistently_ordered = function(se){
+check_if_assays_are_NOT_consistently_ordered <- function(se) {
     
     # If I have any assay at all
     assays(se) |> length() |> gt(0) &&

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -10,8 +10,8 @@
 #'
 #' @return A tibble with an additional attribute
 drop_attr = function(var, name) {
-  attr(var, name) <- NULL
-  var
+    attr(var, name) <- NULL
+    var
 }
 
 #' Drop all attribute to abject
@@ -26,14 +26,14 @@ drop_attr = function(var, name) {
 #' 
 #' @return A tibble with an additional attribute
 drop_all_attr = function(var) {
-  
+    
   N = var %>% attributes() %>% names()
-  
-  for(n in N){
+    
+    for (n in N) {
     var = var %>% drop_attr(n)
-  }
-
-  var
+    }
+    
+    var
 }
 
 #' Get matrix from tibble
@@ -61,33 +61,33 @@ as_matrix <- function(tbl,
   tbl %>%
     
     # Through warning if data frame is not numerical beside the rownames column (if present)
-    when(
-      do_check &&
-        (.) %>%
-        # If rownames defined eliminate it from the data frame
-        when(!quo_is_null(rownames) ~ (.)[,-1], ~ (.)) %>%
-        dplyr::summarise_all(class) %>%
-        tidyr::gather(variable, class) %>%
-        pull(class) %>%
-        unique() %>%
-        `%in%`(c("numeric", "integer")) %>% not() %>% any() ~ {
-        warning("tidybulk says: there are NON-numerical columns, the matrix will NOT be numerical")
-        (.)
-      },
-      ~ (.)
-    ) %>%
-    as.data.frame() %>%
-    
-    # Deal with rownames column if present
-    when(
-      !quo_is_null(rownames) ~ (.) %>%
-        magrittr::set_rownames(tbl %>% pull(!!rownames)) %>%
-        select(-1),
-      ~ (.)
-    ) %>%
-    
-    # Convert to matrix
-    as.matrix()
+        when(
+            do_check &&
+                (.) %>%
+                # If rownames defined eliminate it from the data frame
+                when(!quo_is_null(rownames) ~ (.)[,-1], ~ (.)) %>%
+                dplyr::summarise_all(class) %>%
+                tidyr::gather(variable, class) %>%
+                pull(class) %>%
+                unique() %>%
+                `%in%`(c("numeric", "integer")) %>% not() %>% any() ~ {
+                    warning("tidybulk says: there are NON-numerical columns, the matrix will NOT be numerical")
+                    (.)
+                },
+            ~ (.)
+        ) %>%
+        as.data.frame() %>%
+        
+        # Deal with rownames column if present
+        when(
+            !quo_is_null(rownames) ~ (.) %>%
+                magrittr::set_rownames(tbl %>% pull(!!rownames)) %>%
+                select(-1),
+            ~ (.)
+        ) %>%
+        
+        # Convert to matrix
+        as.matrix()
 }
 
 #' @importFrom tibble as_tibble
@@ -101,7 +101,7 @@ as_matrix <- function(tbl,
 to_tib <- function(.data) {
     colData(.data) %>%
         as.data.frame() %>%
-        as_tibble(rownames="cell")
+        as_tibble(rownames = "cell")
 }
 
 # Greater than
@@ -129,7 +129,7 @@ eq <- function(a, b) {
     a == b
 }
 
-prepend <- function(x, values, before=1) {
+prepend <- function(x, values, before = 1) {
     n <- length(x)
     stopifnot(before > 0 && before <= n)
     if (before == 1) {
@@ -189,8 +189,8 @@ drop_class <- function(var, name) {
 #'
 #'
 #' @noRd
-get_abundance_sc_wide <- function(.data, transcripts=NULL, all=FALSE) {
-
+get_abundance_sc_wide <- function(.data, transcripts = NULL, all = FALSE) {
+    
     # Solve CRAN warnings
     . <- NULL
 
@@ -224,20 +224,20 @@ get_abundance_sc_wide <- function(.data, transcripts=NULL, all=FALSE) {
     else {
         variable_genes <- NULL
     }
-
+    
     # Just grub last assay
     assays(.data) %>%
         as.list() %>%
         tail(1) %>%
         .[[1]] %>%
         when(
-            variable_genes %>% is.null() %>% `!`() ~ (.)[variable_genes, , drop=FALSE],
-            transcripts %>% is.null() %>% `!`() ~ (.)[transcripts, , drop=FALSE],
+            variable_genes %>% is.null() %>% `!`() ~ (.)[variable_genes, , drop = FALSE],
+            transcripts %>% is.null() %>% `!`() ~ (.)[transcripts, , drop = FALSE],
             ~ stop("It is not convenient to extract all genes, you should have either variable features or feature list to extract")
         ) %>%
         as.matrix() %>%
         t() %>%
-        as_tibble(rownames="cell")
+        as_tibble(rownames = "cell")
 }
 
 #' get abundance long
@@ -296,20 +296,20 @@ get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_ze
     else {
         variable_genes <- NULL
     }
-
+    
     assay_names <- assays(.data) %>% names()
-
-
+    
+    
     assays(.data) %>%
         as.list() %>%
-
+        
         # Take active assay
         map2(
             assay_names,
-
+            
             ~ .x %>%
                 when(
-                    variable_genes %>% is.null() %>% `!`() ~ .x[variable_genes, , drop=FALSE],
+                    variable_genes %>% is.null() %>% `!`() ~ .x[variable_genes, , drop = FALSE],
                     transcripts %>% is.null() %>% `!`() ~ .x[toupper(rownames(.x)) %in% toupper(transcripts), , drop=FALSE],
                     all ~ .x,
                     ~ stop("It is not convenient to extract all genes, you should have either variable features or feature list to extract")
@@ -325,15 +325,15 @@ get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_ze
                 data.frame() %>%
                 as_tibble(rownames=f_(.data)$name) %>%
                 tidyr::pivot_longer(
-                    cols=-!!f_(.data)$symbol,
-                    names_to="cell",
-                    values_to="abundance" %>% paste(.y, sep="_"),
-                    values_drop_na=TRUE
+                    cols = -!!f_(.data)$symbol,
+                    names_to = "cell",
+                    values_to = "abundance" %>% paste(.y, sep = "_"),
+                    values_drop_na = TRUE
                 )
             # %>%
             # mutate_if(is.character, as.factor) %>%
         ) %>%
-        Reduce(function(...) left_join(..., by=c(f_(.data)$name, "cell")), .)
+        Reduce(function(...) left_join(..., by = c(f_(.data)$name, "cell")), .)
 }
 
 #' @importFrom methods .hasSlot
@@ -351,155 +351,155 @@ get_abundance_sc_long <- function(.data, transcripts=NULL, all=FALSE, exclude_ze
 #'
 #' @noRd
 update_SE_from_tibble <- function(.data_mutated, se, column_belonging = NULL) {
-
+    
     # Comply to CRAN notes 
     . <- NULL 
-
+    
     # Get the colnames of samples and feature datasets
     colnames_col <- 
-      colnames(colData(se)) %>% 
-      c(s_(se)$name) %>%
-      
-      # Forcefully add the column I know the source. This is useful in nesting 
-      # where a unique value cannot be linked to sample or feature
-      c(names(column_belonging[column_belonging==s_(se)$name]))
+        colnames(colData(se)) %>% 
+        c(s_(se)$name) %>%
+        
+        # Forcefully add the column I know the source. This is useful in nesting 
+        # where a unique value cannot be linked to sample or feature
+        c(names(column_belonging[column_belonging == s_(se)$name]))
     
     colnames_row <- se %>%
-      when(
-        .hasSlot(., "rowData") | .hasSlot(., "elementMetadata") ~ colnames(rowData(.)), 
-        TRUE ~ c()
-      ) %>% 
-      c(f_(se)$name) %>%
-      
-      # Forcefully add the column I know the source. This is useful in nesting 
-      # where a unique value cannot be linked to sample or feature
-      c(names(column_belonging[column_belonging==f_(se)$name]))
+        when(
+            .hasSlot(., "rowData") | .hasSlot(., "elementMetadata") ~ colnames(rowData(.)), 
+            TRUE ~ c()
+        ) %>% 
+        c(f_(se)$name) %>%
+        
+        # Forcefully add the column I know the source. This is useful in nesting 
+        # where a unique value cannot be linked to sample or feature
+        c(names(column_belonging[column_belonging == f_(se)$name]))
     
     secial_columns = get_special_columns(
       
-      # Decrease the size of the dataset
-      se[1:min(100, nrow(se)), 1:min(20, ncol(se))]
+        # Decrease the size of the dataset
+        se[1:min(100, nrow(se)), 1:min(20, ncol(se))]
     ) 
     
     new_colnames_col = 
-      .data_mutated %>%
-      select_if(!colnames(.) %in% setdiff(colnames_col, s_(se)$name)) %>% 
-      
-      # Eliminate special columns that are read only. Assays
-      select_if(!colnames(.) %in% secial_columns) %>%
-      select_if(!colnames(.) %in% colnames_row) %>%
-      # Replace for subset
-      select(!!s_(se)$symbol,     get_subset_columns(., !!s_(se)$symbol)   ) %>% 
-      colnames()
-     
+        .data_mutated %>%
+        select_if(!colnames(.) %in% setdiff(colnames_col, s_(se)$name)) %>% 
+        
+        # Eliminate special columns that are read only. Assays
+        select_if(!colnames(.) %in% secial_columns) %>%
+        select_if(!colnames(.) %in% colnames_row) %>%
+        # Replace for subset
+        select(!!s_(se)$symbol, get_subset_columns(., !!s_(se)$symbol)) %>% 
+        colnames()
+    
     col_data <-
         .data_mutated %>%
-      
-        select(c(colnames_col,new_colnames_col)) %>%
-      
+        
+        select(c(colnames_col, new_colnames_col)) %>%
+        
         # Make fast distinct()
         filter(pull(., !!s_(se)$symbol) %>% duplicated() %>%  not()) %>% 
-      
+        
         # In case unitary SE subset does not work
-        data.frame(row.names=pull(., !!s_(se)$symbol), check.names = FALSE) %>%
+        data.frame(row.names = pull(., !!s_(se)$symbol), check.names = FALSE) %>%
         select(-!!s_(se)$symbol) %>%
         DataFrame(check.names = FALSE)
-
+    
     # This to avoid the mismatch between missing column names for counts 
     # and numerical row names for colData
     row_names_col = 
-      col_data %>%
-      rownames() %>%
-      when(
-        colnames(se) %>% is.null ~ as.integer(.),
-        ~ (.)
-      )
+        col_data %>%
+        rownames() %>%
+        when(
+            colnames(se) %>% is.null ~ as.integer(.),
+            ~ (.)
+        )
     
     row_data <-
         .data_mutated %>%
-      
-       # Eliminate special columns that are read only 
+        
+        # Eliminate special columns that are read only 
         select_if(!colnames(.) %in% secial_columns) %>%
-      
+        
         #eliminate sample columns directly
         select_if(!colnames(.) %in% c(s_(se)$name, colnames(col_data))) %>%
-
+        
         # select(one_of(colnames(rowData(se))))
         # Replace for subset
         select(!!f_(se)$symbol,  get_subset_columns(., !!f_(se)$symbol) ) %>%
-      
+        
         # Make fast distinct()
-        filter(pull(., !!f_(se)$symbol) %>% duplicated() %>%  not()) %>% 
-
+        filter(pull(., !!f_(se)$symbol) %>% duplicated() %>% not()) %>% 
+        
         # In case unitary SE subset does not work because all same
-        data.frame(row.names=pull(.,f_(se)$symbol), check.names = FALSE) %>%
+        data.frame(row.names = pull(.,f_(se)$symbol), check.names = FALSE) %>%
         select(-!!f_(se)$symbol) %>%
         DataFrame(check.names = FALSE)
     
     # This to avoid the mismatch between missing row names for counts 
     # and numerical row names for rowData
     row_names_row = 
-      row_data %>%
-      rownames() %>%
-      when(
-        rownames(se) %>% is.null ~ as.integer(.),
-        ~ (.)
-      )
+        row_data %>%
+        rownames() %>%
+        when(
+            rownames(se) %>% is.null ~ as.integer(.),
+            ~ (.)
+        )
     
     # Subset if needed. This function is used by many dplyr utilities
     se <- se[row_names_row, row_names_col]
-
+    
     # Update
     colData(se) <- col_data
     rowData(se) <- row_data
     
     # Count-like data that is NOT in the assay slot already 
     colnames_assay <-
-      colnames(.data_mutated) %>% 
-      setdiff(c(f_(se)$name, s_(se)$name, colnames(as.data.frame(head(rowRanges(se), 1))) )) %>%
-      setdiff(colnames(col_data)) %>% 
-      setdiff(colnames(row_data)) %>%
-      setdiff(assays(se) %>% names)
+        colnames(.data_mutated) %>% 
+        setdiff(c(f_(se)$name, s_(se)$name, colnames(as.data.frame(head(rowRanges(se), 1))) )) %>%
+        setdiff(colnames(col_data)) %>% 
+        setdiff(colnames(row_data)) %>%
+        setdiff(assays(se) %>% names)
     
-    if(length(colnames_assay)>0)
-      assays(se) = #, withDimnames=FALSE) = 
+    if (length(colnames_assay) > 0)
+        assays(se) = #, withDimnames=FALSE) = 
         assays(se, withDimnames = FALSE) %>% c(
-          .data_mutated %>% 
-            
-            # Select assays column
-            select(!!f_(se)$symbol, !!s_(se)$symbol, colnames_assay) %>% 
-            
-            # Pivot for generalising to many assays
-            pivot_longer(cols = -c(!!s_(se)$symbol, !!f_(se)$symbol)) %>%
-            nest(data___ = c(!!s_(se)$symbol, !!f_(se)$symbol, value)) %>%
-            
-            # Convert to matrix and to named list
-            mutate(data___ = map2(
-              data___, name,
-              ~ {
-                .x = 
-                  .x %>%
-                  spread(!!s_(se)$symbol, value) %>% 
+            .data_mutated %>% 
+                
+                # Select assays column
+                select(!!f_(se)$symbol, !!s_(se)$symbol, colnames_assay) %>% 
+                
+                # Pivot for generalising to many assays
+                pivot_longer(cols = -c(!!s_(se)$symbol, !!f_(se)$symbol)) %>%
+                nest(data___ = c(!!s_(se)$symbol, !!f_(se)$symbol, value)) %>%
+                
+                # Convert to matrix and to named list
+                mutate(data___ = map2(
+                    data___, name,
+                    ~ {
+                        .x = 
+                            .x %>%
+                            spread(!!s_(se)$symbol, value) %>% 
             
                   
-                  as_matrix(rownames = !!f_(se)$symbol)  %>% 
-                  suppressWarnings()
+                            as_matrix(rownames = !!f_(se)$symbol)  %>% 
+                            suppressWarnings()
+                        
+                        # Rearrange if assays has colnames and rownames
+                        if(!is.null(rownames(se)) & !is.null(rownames(.x))) .x = .x[rownames(se),,drop=FALSE]
+                        if(!is.null(colnames(se)) & !is.null(colnames(.x))) .x = .x[,colnames(se),drop=FALSE]
+                        
+                        
+                        .x %>%
+                            
+                            list() %>%
+                            setNames(.y)
+                    }
+                )) %>%
                 
-                # Rearrange if assays has colnames and rownames
-                if(!is.null(rownames(se)) & !is.null(rownames(.x))) .x = .x[rownames(se),,drop=FALSE]
-                if(!is.null(colnames(se)) & !is.null(colnames(.x))) .x = .x[,colnames(se),drop=FALSE]
-
-                
-              .x %>%
-                
-                list() %>%
-                setNames(.y)
-              }
-            )) %>%
-            
-            # Create correct list
-            pull(data___) %>%
-            reduce(c) 
+                # Create correct list
+                pull(data___) %>%
+                reduce(c) 
         )
     
     # return
@@ -508,32 +508,32 @@ update_SE_from_tibble <- function(.data_mutated, se, column_belonging = NULL) {
 
 #' @importFrom methods is
 slice_optimised <- function(.data, ..., .preserve=FALSE) {
-  
-  # This simulated tibble only gets samples and features so we know those that have been completely omitted already
-  # In order to save time for the as_tibble conversion
-  simulated_slice = 
-    simulate_feature_sample_from_tibble(.data) %>% 
-    dplyr::slice(..., .preserve=.preserve)
-  
-  .data = 
-    .data %>%
     
-    # Subset the object for samples and features present in the simulated data
+    # This simulated tibble only gets samples and features so we know those that have been completely omitted already
+    # In order to save time for the as_tibble conversion
+    simulated_slice = 
+        simulate_feature_sample_from_tibble(.data) %>% 
+        dplyr::slice(..., .preserve = .preserve)
+    
+    .data = 
+        .data %>%
+        
+        # Subset the object for samples and features present in the simulated data
     .[rownames(.) %in% simulated_slice[,f_(.)$name], colnames(.) %in% simulated_slice[,s_(.)$name]] %>% 
-    inner_join(simulated_slice, by = c(f_(.)$name, s_(.)$name)) 
-  
-  # If order do not match with the one proposed by slice convert to tibble
-  if(.data %>% is("tbl") %>% not()){
-    .data_for_match = .data %>%  select(!!f_(.data)$symbol, !!s_(.data)$symbol) %>% as_tibble() 
+        inner_join(simulated_slice, by = c(f_(.)$name, s_(.)$name)) 
     
+    # If order do not match with the one proposed by slice convert to tibble
+    if (.data %>% is("tbl") %>% not()) {
+    .data_for_match = .data %>%  select(!!f_(.data)$symbol, !!s_(.data)$symbol) %>% as_tibble() 
+        
     x = c(pull(.data_for_match, !!f_(.data)$symbol), pull(.data_for_match, !!s_(.data)$symbol))
     y =  c(pull(simulated_slice, !!f_(.data)$symbol), pull(simulated_slice, !!s_(.data)$symbol))
-    
+        
     if( identical(x, y) %>% not())
-      left_join(simulated_slice, as_tibble(.data), by = c(f_(.data)$name, s_(.data)$name))
+            left_join(simulated_slice, as_tibble(.data), by = c(f_(.data)$name, s_(.data)$name))
     else
-      .data
-  }
+            .data
+        }
   
  
 }
@@ -551,7 +551,7 @@ slice_optimised <- function(.data, ..., .preserve=FALSE) {
 get_special_columns <- function(.data) {
     colnames_special <-
         get_special_datasets(.data) %>%
-
+        
         # In case any of those have feature of sample in column names
         map(
             ~ .x %>%
@@ -560,12 +560,12 @@ get_special_columns <- function(.data) {
         ) %>%
         unlist() %>%
         as.character()
-
+    
     colnames_counts <-
         get_count_datasets(.data) %>%
         select(-!!f_(.data)$symbol, -!!s_(.data)$symbol) %>%
         colnames()
-
+    
     colnames_special %>% c(colnames_counts)
 }
 
@@ -578,45 +578,104 @@ get_special_columns <- function(.data) {
 #' 
 #' @noRd
 get_special_datasets <- function(se) {
-  
-  rr =  se %>%
-    rowRanges() 
-  
-  rr %>%
-    when( 
-      
-      # If no ranges
-      as.data.frame(.) %>%
-      nrow() %>%
-      equals(0) ~ tibble(),
-      
-      # If it is a range list (multiple rows per feature)
-      is(., "CompressedGRangesList") ~ {
-        
-        # If GRanges does not have row names
+    
+    rr =  se %>%
+        rowRanges() 
+    
+    rr %>%
+        when( 
+            
+            # If no ranges
+            as.data.frame(.) %>%
+                nrow() %>%
+                equals(0) ~ tibble(),
+            
+            # If it is a range list (multiple rows per feature)
+            is(., "CompressedGRangesList") ~ {
+                
+                # If GRanges does not have row names
         if(is.null(rr@partitioning@NAMES)) rr@partitioning@NAMES = as.character(1:nrow(se))
-        
-        tibble::as_tibble(rr) %>%
-          eliminate_GRanges_metadata_columns_also_present_in_Rowdata(se) %>%
-          nest(GRangesList = -group_name) %>%
-          rename(!!f_(se)$symbol := group_name)
-        
-      },
-      
-      # If standard GRanges (one feature per line)
-      ~ {
-        
-        # If GRanges does not have row names
-       if(is.null(rr@ranges@NAMES)) rr@ranges@NAMES = as.character(1:nrow(se))
-         
-        tibble::as_tibble(rr) %>% 
-          eliminate_GRanges_metadata_columns_also_present_in_Rowdata(se) %>% 
-        mutate(!!f_(se)$symbol := rr@ranges@NAMES) 
-      }
+                
+                tibble::as_tibble(rr) %>%
+                    eliminate_GRanges_metadata_columns_also_present_in_Rowdata(se) %>%
+                    nest(GRangesList = -group_name) %>%
+                    rename(!!f_(se)$symbol := group_name)
+                
+            },
+            
+            # If standard GRanges (one feature per line)
+            ~ {
+                
+                # If GRanges does not have row names
+                if (is.null(rr@ranges@NAMES)) {
+                    rr@ranges@NAMES <- as.character(1:nrow(se))
+                }
+                
+                tibble::as_tibble(rr) %>% 
+                    eliminate_GRanges_metadata_columns_also_present_in_Rowdata(se) %>% 
+                    mutate(!!f_(se)$symbol := rr@ranges@NAMES) 
+            }
+            
+        ) %>%
+        list()
+}
 
-    ) %>%
-    list()
-  
+check_se_dimnames <- function(se) {
+    # Stop if column names of assays do not overlap, or if some assays have 
+    # column names and others don't
+    if (check_if_assays_are_NOT_overlapped(se, dim = "cols")) { 
+        stop( 
+            "tidySummarizedExperiment says: at least one of the assays in your SummarizedExperiment have column names, but they don't completely overlap between assays." 
+        )
+    }
+    # Same for row names
+    if (check_if_assays_are_NOT_overlapped(se, dim = "rows")) { 
+        stop( 
+            "tidySummarizedExperiment says: at least one of the assays in your SummarizedExperiment have row names, but they don't completely overlap between assays." 
+        )
+    }
+    
+    # If the assays have dimnames but the SE does not, throw a warning and set 
+    # the dimnames of the SE to those of the first assay with dimnames.
+    # (At this point we know that all assays have the same dimnames (could be 
+    # NULL), but they could be in different order)
+    if (is.null(colnames(se)) && 
+        length(assays(se)) > 0 && 
+        !is.null(colnames(assays(se, withDimnames = FALSE)[[1]]))) {
+        warning(
+            "tidySummarizedExperiment says: the assays in your SummarizedExperiment have column names, but the SummarizedExperiment does not. Setting colnames(se) to column names of first assay."
+        )
+        colnames(se) <- colnames(assays(se, withDimnames = FALSE)[[1]])
+    }
+    if (is.null(rownames(se)) && 
+        length(assays(se)) > 0 && 
+        !is.null(rownames(assays(se, withDimnames = FALSE)[[1]]))) {
+        warning(
+            "tidySummarizedExperiment says: the assays in your SummarizedExperiment have row names, but the SummarizedExperiment does not. Setting rownames(se) to row names of first assay."
+        )
+        rownames(se) <- rownames(assays(se, withDimnames = FALSE)[[1]])
+    }
+    
+    # If the assays as well as the SE have dimnames, but they don't overlap 
+    # (they may be in different order), throw an error.
+    if (!is.null(colnames(se)) &&
+        length(assays(se)) > 0 && 
+        !is.null(colnames(assays(se, withDimnames = FALSE)[[1]])) && 
+        !all(colnames(assays(se, withDimnames = FALSE)[[1]]) %in% colnames(se))) {
+        stop(
+            "tidySummarizedExperiment says: the assays in your SummarizedExperiment have column names, but they don't agree with the column names of the SummarizedExperiment object itself."
+        )
+    }
+    if (!is.null(rownames(se)) &&
+        length(assays(se)) > 0 && 
+        !is.null(rownames(assays(se, withDimnames = FALSE)[[1]])) && 
+        !all(rownames(assays(se, withDimnames = FALSE)[[1]]) %in% rownames(se))) {
+        stop(
+            "tidySummarizedExperiment says: the assays in your SummarizedExperiment have row names, but they don't agree with the row names of the SummarizedExperiment object itself."
+        )
+    }
+    
+    se
 }
 
 #' @importFrom tidyr gather
@@ -629,72 +688,67 @@ get_special_datasets <- function(se) {
 #' 
 #' @noRd
 get_count_datasets <- function(se) { 
-  
-  # Stop if column names of assays do not overlap
-  if( check_if_assays_are_NOT_overlapped(se) ) 
-    stop( 
-    "tidySummarizedExperiment says: the assays in your SummarizedExperiment have column names, 
-but their order is not the same, and they not completely overlap." 
-  )
-
-  # Join assays
-  map2( 
-    assays(se, withDimnames = FALSE) %>% as.list(),
-    names(assays(se)),
-    ~ {
-      
-      # If the counts are in a sparse matrix convert to a matrix
-      # This might happen because the user loaded tidySummarizedExperiment and is 
-      # print a SingleCellExperiment
-      if(is(.x, "dgCMatrix") | is(.x, "DelayedArray")) {
+    # Check that dimnames are consistent
+    se <- check_se_dimnames(se)
+    
+    # Join assays
+    map2( 
+        assays(se, withDimnames = FALSE) %>% as.list(),
+        names(assays(se)),
+        ~ {
+            
+            # If the counts are in a sparse matrix convert to a matrix
+            # This might happen because the user loaded tidySummarizedExperiment and is 
+            # print a SingleCellExperiment
+            if (is(.x, "dgCMatrix") | is(.x, "DelayedArray")) {
         .x = as.matrix(.x) 
-      }
-      
-      # Rearrange if assays has colnames and rownames
-      if(!is.null(rownames(se)) & !is.null(rownames(.x))) .x = .x[rownames(se),,drop=FALSE]
-      if(!is.null(colnames(se)) & !is.null(colnames(.x))) .x = .x[,colnames(se),drop=FALSE]
-
-      # If I don't have assay colnames and rownames add them
-      if(!is.null(rownames(se)) & is.null(rownames(.x))) rownames(.x) = rownames(se) 
-      if(!is.null(colnames(se)) & is.null(colnames(.x))) colnames(.x) = colnames(se) 
-      
-      .x %>%
-      # matrix() %>%
-      # as.data.frame() %>% 
-        
-      tibble::as_tibble(rownames = f_(se)$name, .name_repair = "minimal") %>%
-      
-      # If the matrix does not have sample names, fix column names
-      when(colnames(.x) %>% is.null() & is.null(colnames(se)) ~ setNames(., c(
-        f_(se)$name,  seq_len(ncol(.x)) 
-      )),
-      ~ (.)
-    ) %>%
-      
-      gather(!!s_(se)$symbol, !!.y,-!!f_(se)$symbol) 
-    
-    #%>%
-    #  rename(!!.y := count)
-  }) %>%
-    when(
-      length(.)>0 ~ 
-        
-        # reduce(., left_join, by = c(f_(se)$name, s_(se)$name)),
-        bind_cols(.,  .name_repair = c("minimal")) %>% .[!duplicated(colnames(.))], 
-      ~ expand.grid(
-        rownames(se), colnames(se)
+            }
+            
+            # Rearrange if assays has colnames and rownames
+            if (!is.null(rownames(se)) & !is.null(rownames(.x))) .x = .x[rownames(se), , drop = FALSE]
+            if (!is.null(colnames(se)) & !is.null(colnames(.x))) .x = .x[, colnames(se), drop = FALSE]
+            
+            # If I don't have assay colnames and rownames add them
+            if (!is.null(rownames(se)) & is.null(rownames(.x))) rownames(.x) = rownames(se) 
+            if (!is.null(colnames(se)) & is.null(colnames(.x))) colnames(.x) = colnames(se) 
+            
+            .x %>%
+                # matrix() %>%
+                # as.data.frame() %>% 
+                
+                tibble::as_tibble(rownames = f_(se)$name, .name_repair = "minimal") %>%
+                
+                # If the matrix does not have sample names, fix column names
+                when(colnames(.x) %>% is.null() & is.null(colnames(se)) ~ setNames(., c(
+                    f_(se)$name,  seq_len(ncol(.x)) 
+                )),
+                ~ (.)
+                ) %>%
+                
+                gather(!!s_(se)$symbol, !!.y,-!!f_(se)$symbol) 
+            
+            #%>%
+            #  rename(!!.y := count)
+        }) %>%
+        when(
+            length(.)>0 ~ 
+                
+                # reduce(., left_join, by = c(f_(se)$name, s_(se)$name)),
+                bind_cols(.,  .name_repair = c("minimal")) %>% .[!duplicated(colnames(.))], 
+            ~ expand.grid(
+                rownames(se), colnames(se)
+            ) %>% 
+                setNames(c(f_(se)$name, s_(se)$name)) %>%
+                tibble::as_tibble()
         ) %>% 
-        setNames(c(f_(se)$name, s_(se)$name)) %>%
-        tibble::as_tibble()
-    ) %>% 
-    
-    # Add dummy sample or feature if we have empty assay. 
+        
+        # Add dummy sample or feature if we have empty assay. 
     # This is needed for a correct isualisation of the tibble form
-    when(
-      f_(se)$name %in% colnames(.) %>% not ~ mutate(., !!f_(se)$symbol := as.character(NA)),
-      s_(se)$name %in% colnames(.) %>% not ~ mutate(., !!s_(se)$symbol := as.character(NA)),
-      ~ (.)
-    )
+        when(
+            f_(se)$name %in% colnames(.) %>% not ~ mutate(., !!f_(se)$symbol := as.character(NA)),
+            s_(se)$name %in% colnames(.) %>% not ~ mutate(., !!s_(se)$symbol := as.character(NA)),
+            ~ (.)
+        )
 }
 
 get_needed_columns <- function(.data) {
@@ -728,7 +782,7 @@ quo_names <- function(v) {
 #' @noRd
 select_helper <- function(.data, ...) {
     loc <- tidyselect::eval_select(expr(c(...)), .data)
-
+    
     dplyr::select(.data, loc)
 }
 
@@ -746,26 +800,26 @@ outersect <- function(x, y) {
 #' 
 #' @noRd
 get_subset_columns <- function(.data, .col) {
-
+    
 
     # Comply with CRAN NOTES
     . <- NULL
-
+    
     # Make col names
     .col <- enquo(.col)
- 
+    
     # x-annotation df
     n_x <- .data %>%
         distinct_at(vars(!!.col)) %>%
         nrow()
-
+    
     # element wise columns
     .data %>%
         select(-!!.col) %>%
         colnames() %>%
         map(
             ~
-            .x %>%
+                .x %>%
                 when(
                     .data %>%
                         distinct_at(vars(!!.col, .x)) %>%
@@ -774,7 +828,7 @@ get_subset_columns <- function(.data, .col) {
                     ~NULL
                 )
         ) %>%
-
+        
         # Drop NULL
         {
             (.)[lengths((.)) != 0]
@@ -808,252 +862,252 @@ is_split_by_sample = function(.my_data){
 
 
 get_GRanges_colnames = function(){
-  "GenomicRanges"
+    "GenomicRanges"
 }
 
 
 eliminate_GRanges_metadata_columns_also_present_in_Rowdata = function(.my_data, se){
-  .my_data %>%
-    select(-one_of(colnames(rowData(se)))) %>%
-    
-    # In case there is not metadata column
-    suppressWarnings() 
+    .my_data %>%
+        select(-one_of(colnames(rowData(se)))) %>%
+        
+        # In case there is not metadata column
+        suppressWarnings() 
 }
 
 subset_tibble_output = function(.data, count_info, sample_info, gene_info, range_info, .subset){
-  # This function outputs a tibble after subsetting the columns
+    # This function outputs a tibble after subsetting the columns
   .subset = enquo(.subset)
-  
-  # Build template of the output
+    
+    # Build template of the output
   output_colnames = 
-    slice(count_info, 0) %>%
-    left_join(slice(sample_info, 0), by=s_(.data)$name) %>%
-    left_join(slice(gene_info, 0), by = f_(.data)$name) %>%
-    when(nrow(range_info) > 0 ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.)) %>%
-    select(!!.subset) %>%
-    colnames()
-  
-  
-  # Sample table
+        slice(count_info, 0) %>%
+        left_join(slice(sample_info, 0), by = s_(.data)$name) %>%
+        left_join(slice(gene_info, 0), by = f_(.data)$name) %>%
+        when(nrow(range_info) > 0 ~ (.) %>% left_join(range_info, by = f_(.data)$name), ~ (.)) %>%
+        select(!!.subset) %>%
+        colnames()
+    
+    
+    # Sample table
   sample_info = 
-    sample_info %>%
-    when(
-      colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
-      select(., one_of(s_(.data)$name, output_colnames)) %>%
-        suppressWarnings()
-    )
-  
-  # Ranges table
+        sample_info %>%
+        when(
+            colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
+            select(., one_of(s_(.data)$name, output_colnames)) %>%
+                suppressWarnings()
+        )
+    
+    # Ranges table
   range_info = 
-    range_info %>%
-    when(
-      colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
-      select(., one_of(f_(.data)$name, output_colnames)) %>%
-        suppressWarnings()
-    )
-  
-  # Ranges table
+        range_info %>%
+        when(
+            colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
+            select(., one_of(f_(.data)$name, output_colnames)) %>%
+                suppressWarnings()
+        )
+    
+    # Ranges table
   gene_info = 
-    gene_info %>%
-    when(
-      colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
-      select(., one_of(f_(.data)$name, output_colnames)) %>%
-        suppressWarnings()
-    )
-  
+        gene_info %>%
+        when(
+            colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
+            select(., one_of(f_(.data)$name, output_colnames)) %>%
+                suppressWarnings()
+        )
+    
   # Ranges table
   count_info = 
-    count_info %>%
-    when(
-      colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
-      select(., one_of(f_(.data)$name, s_(.data)$name, output_colnames)) %>%
-        suppressWarnings()
-    )
+        count_info %>%
+        when(
+            colnames(.) %>% intersect(output_colnames) %>% length() %>% equals(0) ~ NULL,
+            select(., one_of(f_(.data)$name, s_(.data)$name, output_colnames)) %>%
+                suppressWarnings()
+        )
   
   
-  if(
-    !is.null(count_info) & 
-    (
-      !is.null(sample_info) & !is.null(gene_info) | 
-    
-      # Make exception for weirs cases (e.g. c(sample, counts))
+    if (
+        !is.null(count_info) & 
+        (
+            !is.null(sample_info) & !is.null(gene_info) | 
+            
+            # Make exception for weirs cases (e.g. c(sample, counts))
       (colnames(count_info) %>% outersect(c(f_(.data)$name, s_(.data)$name)) %>% length() %>% gt(0))
-    )
-  ) {
+        )
+    ) {
     output_df = 
-      count_info %>%
-      when(!is.null(sample_info) ~ (.) %>% left_join(sample_info, by=s_(.data)$name), ~ (.)) %>%
-      when(!is.null(gene_info) ~ (.) %>% left_join(gene_info, by=f_(.data)$name), ~ (.)) %>%
-      when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
+            count_info %>%
+            when(!is.null(sample_info) ~ (.) %>% left_join(sample_info, by=s_(.data)$name), ~ (.)) %>%
+            when(!is.null(gene_info) ~ (.) %>% left_join(gene_info, by=f_(.data)$name), ~ (.)) %>%
+            when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
   }
   else if(!is.null(sample_info) ){
     output_df = sample_info
   }
   else if(!is.null(gene_info)){
     output_df = gene_info %>%
-      
-      # If present join GRanges
-      when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
-  }
-  
-  output_df %>%
+            
+            # If present join GRanges
+            when(!is.null(range_info) ~ (.) %>% left_join(range_info, by=f_(.data)$name), ~ (.))
+    }
     
-    # Cleanup
-    select(one_of(output_colnames)) %>%
-    suppressWarnings()
+    output_df %>%
+        
+        # Cleanup
+        select(one_of(output_colnames)) %>%
+        suppressWarnings()
   
 }
 
 #' @importFrom stringr str_replace
 change_reserved_column_names = function(col_data, .data ){
-  
-  # Fix  NOTEs
-  . = NULL
-  
-  col_data %>%
     
-    setNames(
-      colnames(.) %>% 
-        sapply(function(x) if(x==f_(.data)$name) sprintf("%s.x", f_(.data)$name) else x) %>% 
-        sapply(function(x) if(x==s_(.data)$name) sprintf("%s.x", s_(.data)$name) else x) %>% 
-        str_replace("^coordinate$", "coordinate.x")
-    ) 
-  
+    # Fix  NOTEs
+    . = NULL
+    
+    col_data %>%
+        
+        setNames(
+            colnames(.) %>% 
+                sapply(function(x) if (x == f_(.data)$name) sprintf("%s.x", f_(.data)$name) else x) %>% 
+                sapply(function(x) if (x == s_(.data)$name) sprintf("%s.x", s_(.data)$name) else x) %>% 
+                str_replace("^coordinate$", "coordinate.x")
+        ) 
+    
 }
 
 choose_name_if_present = function(x){
   columns_query = c()
-  for(i in 1:length(x)){
+    for (i in 1:length(x)) {
     if(is.null(names(x[i]))) columns_query[i] = x[i]
     else columns_query[i] = names(x[i])
-  }
-  
-  columns_query
+    }
+    
+    columns_query
 }
 
 #' @importFrom purrr when
 join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"), join_function, force_tibble_route = FALSE,
                                   ...) {
-  
+    
   
    
-  # Comply to CRAN notes 
-  . <- NULL 
-  
-  # Deprecation of special column names
-  if(is_sample_feature_deprecated_used( x, when(by, !is.null(.) ~ by, ~ colnames(y)))){
+    # Comply to CRAN notes 
+    . <- NULL 
+    
+    # Deprecation of special column names
+    if (is_sample_feature_deprecated_used(x, when(by, !is.null(.) ~ by, ~ colnames(y)))) {
     x= ping_old_special_column_into_metadata(x)
-  }
-  
-  # Get the colnames of samples and feature datasets
-  colnames_col <- get_colnames_col(x)
-  colnames_row <- get_rownames_col(x)
-  
-  # See if join done by sample, feature or both
+    }
+    
+    # Get the colnames of samples and feature datasets
+    colnames_col <- get_colnames_col(x)
+    colnames_row <- get_rownames_col(x)
+    
+    # See if join done by sample, feature or both
   columns_query = by %>% when(
-    !is.null(.) ~ choose_name_if_present(.), 
-    ~ colnames(y) %>% intersect(c(colnames_col, colnames_row))
-  )
-  
-  if(
+        !is.null(.) ~ choose_name_if_present(.), 
+        ~ colnames(y) %>% intersect(c(colnames_col, colnames_row))
+    )
     
-    # Complex join that it is not efficient yet
-    (any(columns_query %in% colnames_row) & any(columns_query %in% colnames_col)) |
+    if (
     
-    # If join is with something else, the inefficient generic solution might work, 
-    # or delegate the proper error downstream
-    (!any(columns_query %in% colnames_row) & !any(columns_query %in% colnames_col)) |
-    
-    # Needed for internal recurrence if outcome is not valid
-    force_tibble_route) {
-    
-    
-    
-    # If I have a big dataset
-    if(ncol(x)>100) message("tidySummarizedExperiment says: if you are joining a dataframe both sample-wise and feature-wise, for efficiency (until further development), it is better to separate your joins and join datasets sample-wise OR feature-wise.")
-    
-    x %>%
-      as_tibble(skip_GRanges  = TRUE) %>%
-      join_function(y, by=by, copy=copy, suffix=suffix, ...) %>%
-      when(
+        # Complex join that it is not efficient yet
+        (any(columns_query %in% colnames_row) & any(columns_query %in% colnames_col)) |
         
-        # If duplicated sample-feature pair returns tibble
-        !is_not_duplicated(., x) | !is_rectangular(., x) ~ {
-          message(duplicated_cell_names)
-          message(data_frame_returned_message)
-          (.)
-        },
+        # If join is with something else, the inefficient generic solution might work, 
+        # or delegate the proper error downstream
+        (!any(columns_query %in% colnames_row) & !any(columns_query %in% colnames_col)) |
         
-        # Otherwise return updated tidySummarizedExperiment
-        ~ update_SE_from_tibble(., x)
-      )
+        # Needed for internal recurrence if outcome is not valid
+        force_tibble_route) {
+        
     
-  }
-  
-  # Join only feature-wise
-  else if(any(columns_query %in% colnames_row) & !any(columns_query %in% colnames_col)) {
     
+        # If I have a big dataset
+        if (ncol(x) > 100) message("tidySummarizedExperiment says: if you are joining a dataframe both sample-wise and feature-wise, for efficiency (until further development), it is better to separate your joins and join datasets sample-wise OR feature-wise.")
+        
+        x %>%
+            as_tibble(skip_GRanges = TRUE) %>%
+            join_function(y, by = by, copy = copy, suffix = suffix, ...) %>%
+            when(
+                
+                # If duplicated sample-feature pair returns tibble
+                !is_not_duplicated(., x) | !is_rectangular(., x) ~ {
+                    message(duplicated_cell_names)
+                    message(data_frame_returned_message)
+                    (.)
+                },
+                
+                # Otherwise return updated tidySummarizedExperiment
+                ~ update_SE_from_tibble(., x)
+            )
+        
+    }
+    
+    # Join only feature-wise
+    else if (any(columns_query %in% colnames_row) & !any(columns_query %in% colnames_col)) {
+        
     row_data_tibble = 
-      rowData(x) %>% 
-      as_tibble(rownames = f_(x)$name) %>%  
-      join_function(y, by=by, copy=copy, suffix=suffix, ...) 
-    
-    # Check if the result is not SE then take the tibble route
-    if(
-      is.na(pull(row_data_tibble, !!f_(x)$symbol)) %>% any | 
-      duplicated(pull(row_data_tibble, !!f_(x)$symbol)) %>% any |
-      pull(row_data_tibble, !!f_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
+            rowData(x) %>% 
+            as_tibble(rownames = f_(x)$name) %>%  
+            join_function(y, by = by, copy = copy, suffix = suffix, ...) 
+        
+        # Check if the result is not SE then take the tibble route
+        if (
+            is.na(pull(row_data_tibble, !!f_(x)$symbol)) %>% any | 
+            duplicated(pull(row_data_tibble, !!f_(x)$symbol)) %>% any |
+            pull(row_data_tibble, !!f_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
     ) return(join_efficient_for_SE(x, y, by=by, copy=copy, suffix=suffix, join_function, force_tibble_route = TRUE, ...))
-    
+        
     row_data = 
-      row_data_tibble %>% 
-      data.frame(row.names=pull(., !!f_(x)$symbol)) %>%
-      select(-!!f_(x)$symbol) %>%
-      DataFrame()
-    
-    # Subset in case of an inner join, or a right join
+            row_data_tibble %>% 
+            data.frame(row.names = pull(., !!f_(x)$symbol)) %>%
+            select(-!!f_(x)$symbol) %>%
+            DataFrame()
+        
+        # Subset in case of an inner join, or a right join
     x = x[rownames(row_data),]  
-    
-    # Tranfer annotation
+        
+        # Tranfer annotation
     rowData(x) = row_data
+        
+        # Return
+        x
+    }
     
-    # Return
-    x
-  }
-  
-  # Join only sample-wise
-  else if(any(columns_query %in% colnames_col) & !any(columns_query %in% colnames_row)) {
-    
+    # Join only sample-wise
+    else if (any(columns_query %in% colnames_col) & !any(columns_query %in% colnames_row)) {
+        
     col_data_tibble = 
-      colData(x) %>% 
-      as_tibble(rownames = s_(x)$name) %>%  
-      join_function(y, by=by, copy=copy, suffix=suffix, ...)
-    
-    # Check if the result is not SE then take the tibble route
-    if(
-      is.na(pull(col_data_tibble, !!s_(x)$symbol)) %>% any | 
-      duplicated(pull(col_data_tibble, !!s_(x)$symbol)) %>% any |
-      pull(col_data_tibble, !!s_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
+            colData(x) %>% 
+            as_tibble(rownames = s_(x)$name) %>%  
+            join_function(y, by = by, copy = copy, suffix = suffix, ...)
+        
+        # Check if the result is not SE then take the tibble route
+        if (
+            is.na(pull(col_data_tibble, !!s_(x)$symbol)) %>% any | 
+            duplicated(pull(col_data_tibble, !!s_(x)$symbol)) %>% any |
+            pull(col_data_tibble, !!s_(x)$symbol) %>% setdiff(rownames(colData(x))) %>% length() %>% gt(0)
     ) return(join_efficient_for_SE(x, y, by=by, copy=copy, suffix=suffix, join_function, force_tibble_route = TRUE, ...))
     
     col_data = 
-      col_data_tibble %>% 
-      data.frame(row.names=pull(., !!s_(x)$symbol)) %>%
-      select(-!!s_(x)$symbol) %>%
-      DataFrame()
+            col_data_tibble %>% 
+            data.frame(row.names = pull(., !!s_(x)$symbol)) %>%
+            select(-!!s_(x)$symbol) %>%
+            DataFrame()
+        
     
-    
-    # Subset in case of an inner join, or a right join
+        # Subset in case of an inner join, or a right join
     x = x[,rownames(col_data)]  
-    
+        
     # Tranfer annotation
     colData(x) = col_data
+        
+        # Return
+        x
+    }
     
-    # Return
-    x
-  }
-  
-  else stop("tidySummarizedExperiment says: ERROR FOR DEVELOPERS: this option should not exist. In join utility.")
+    else stop("tidySummarizedExperiment says: ERROR FOR DEVELOPERS: this option should not exist. In join utility.")
   
   
   
@@ -1061,21 +1115,21 @@ join_efficient_for_SE <- function(x, y, by=NULL, copy=FALSE, suffix=c(".x", ".y"
 
 get_ellipse_colnames = function(...){
   
-  (enquos(..., .ignore_empty = "all") %>% map(~ quo_name(.x)) %>% unlist)
+    (enquos(..., .ignore_empty = "all") %>% map(~ quo_name(.x)) %>% unlist)
 }
 
 get_colnames_col = function(x){
-  colnames(colData(x)) %>% 
-    c(s_(x)$name) 
+    colnames(colData(x)) %>% 
+        c(s_(x)$name) 
 }
 
 get_rownames_col = function(x){
-  x %>%
-    when(
-      .hasSlot(., "rowData") | .hasSlot(., "elementMetadata") ~ colnames(rowData(.)), 
-      TRUE ~ c()
-    ) %>% 
-    c(f_(x)$name) 
+    x %>%
+        when(
+            .hasSlot(., "rowData") | .hasSlot(., "elementMetadata") ~ colnames(rowData(.)), 
+            TRUE ~ c()
+        ) %>% 
+        c(f_(x)$name) 
 
 }
 
@@ -1086,28 +1140,28 @@ get_rownames_col = function(x){
 is_sample_feature_deprecated_used = function(.data, user_columns, use_old_special_names = FALSE){
   
   old_standard_is_used_for_sample =  
-    (
+        (
       ( any(str_detect(user_columns  , regex("\\bsample\\b"))) & !any(str_detect(user_columns  , regex("\\W*(\\.sample)\\W*")))  ) |
-        "sample" %in% user_columns 
-    ) & 
-    !"sample" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
+                "sample" %in% user_columns 
+        ) & 
+        !"sample" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
   
   old_standard_is_used_for_feature = 
-    (
+        (
       ( any(str_detect(user_columns  , regex("\\bfeature\\b"))) & !any(str_detect(user_columns  , regex("\\W*(\\.feature)\\W*")))  ) |
-        "feature" %in% user_columns 
-    ) & 
-    !"feature" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
+                "feature" %in% user_columns 
+        ) & 
+        !"feature" %in% c(colnames(rowData(.data)), colnames(colData(.data)))
   
   old_standard_is_used = old_standard_is_used_for_sample | old_standard_is_used_for_feature
   
-  if(old_standard_is_used){
-    warning("tidySummarizedExperiment says: from version 1.3.1, the special columns including sample/feature id (colnames(se), rownames(se)) has changed to \".sample\" and \".feature\". This dataset is returned with the old-style vocabulary (feature and sample), however we suggest to update your workflow to reflect the new vocabulary (.feature, .sample)")
+    if (old_standard_is_used) {
+        warning("tidySummarizedExperiment says: from version 1.3.1, the special columns including sample/feature id (colnames(se), rownames(se)) has changed to \".sample\" and \".feature\". This dataset is returned with the old-style vocabulary (feature and sample), however we suggest to update your workflow to reflect the new vocabulary (.feature, .sample)")
     
     use_old_special_names = TRUE
-  }
-  
-  use_old_special_names
+    }
+    
+    use_old_special_names
 }
   
 data_frame_returned_message = "tidySummarizedExperiment says: A data frame is returned for independent data analysis."
@@ -1117,15 +1171,15 @@ duplicated_cell_names = "tidySummarizedExperiment says: This operation lead to d
 #' @importFrom S4Vectors metadata
 #' @importFrom S4Vectors metadata<-
 ping_old_special_column_into_metadata = function(.data){
-  
+    
   metadata(.data)$feature__ = get_special_column_name_symbol("feature")
   metadata(.data)$sample__ = get_special_column_name_symbol("sample")
-  
-  .data
+    
+    .data
 }
 
 get_special_column_name_symbol = function(name){
-  list(name = name, symbol = as.symbol(name))
+    list(name = name, symbol = as.symbol(name))
 }
 
 # This function produce artificially the feature ans sample column, 
@@ -1135,7 +1189,7 @@ simulate_feature_sample_from_tibble = function(.data){
   
   r = rownames(.data) %>% .[rep(1:length(.), ncol(.data) )]
   c = colnames(.data) %>% .[rep(1:length(.), each=nrow(.data) )]
-  
+    
     tibble(!!f_(.data)$symbol := r,  !!s_(.data)$symbol := c)
   
 }
@@ -1147,21 +1201,21 @@ sample__ = get_special_column_name_symbol(".sample")
 
 #' @importFrom S4Vectors metadata
 f_ =  function(x){
-  # Check if old deprecated columns are used
-  if("feature__" %in% names(metadata(x))) feature__ = metadata(x)$feature__
-  return(feature__)
+    # Check if old deprecated columns are used
+    if ("feature__" %in% names(metadata(x))) feature__ = metadata(x)$feature__
+    return(feature__)
 }
 
 #' @importFrom S4Vectors metadata
 s_ = function(x){
-  if("sample__" %in% names(metadata(x))) sample__ = metadata(x)$sample__
-  return(sample__)
+    if ("sample__" %in% names(metadata(x))) sample__ = metadata(x)$sample__
+    return(sample__)
 }
 
 split_SummarizedExperiment_by_feature_to_list = function(.data){
-  if(nrow(.data)>1000)
-    message("tidySummarizedExperiment says: grouping a SummarizedExperiment by feature takes 1 minute for ~ 10,000 features.")
-  map(1:nrow(.data), ~ .data[.x,])
+    if (nrow(.data) > 1000)
+        message("tidySummarizedExperiment says: grouping a SummarizedExperiment by feature takes 1 minute for ~ 10,000 features.")
+    map(1:nrow(.data), ~ .data[.x,])
 }
 
 #' Add attribute to abject
@@ -1176,88 +1230,99 @@ split_SummarizedExperiment_by_feature_to_list = function(.data){
 #'
 #' @return A tibble with an additional attribute
 add_attr = function(var, attribute, name) {
-  attr(var, name) <- attribute
-  var
+    attr(var, name) <- attribute
+    var
 }
 
 is_filer_columns_in_column_selection = function(.data, ...){
-  # columns = enquos(columns)
-  tryCatch({
-    .data |>
-      slice(0) |>
-      dplyr::filter(...)
-    TRUE
-  },
-  error = function(e) FALSE)
+    # columns = enquos(columns)
+    tryCatch({
+        .data |>
+            slice(0) |>
+            dplyr::filter(...)
+        TRUE
+    },
+    error = function(e) FALSE)
 }
 
 check_if_assays_are_NOT_consistently_ordered = function(se){
-  
-  # If I have any assay at all
-  assays(se) |> length() |> gt(0) &&
     
-    # If I have more than one assay with colnames
-    Filter(
-      Negate(is.null),
-      assays(se, withDimnames = FALSE) |>  
-        as.list() |> 
-        map(colnames)
-    ) |> 
-    length() |>
-    gt(0) &&
-    
-  # If I have lack of consistency
-  se |> 
-    assays(withDimnames = FALSE) |>
-    as.list() |>
-    purrr::map_dfr(colnames) |>
-    apply(1, function(x) x |> unique() |> length()) |>
-    equals(1) |>
-    all() |>  
-    not()
+    # If I have any assay at all
+    assays(se) |> length() |> gt(0) &&
+        
+        # If I have more than one assay with colnames
+        Filter(
+            Negate(is.null),
+            assays(se, withDimnames = FALSE) |>  
+                as.list() |> 
+                map(colnames)
+        ) |> 
+        length() |>
+        gt(0) &&
+        
+        # If I have lack of consistency
+        se |> 
+        assays(withDimnames = FALSE) |>
+        as.list() |>
+        purrr::map_dfr(colnames) |>
+        apply(1, function(x) x |> unique() |> length()) |>
+        equals(1) |>
+        all() |>  
+        not()
 }
 
-check_if_assays_are_NOT_overlapped = function(se){
-  
-  # If I have any assay at all
-  assays(se) |> length() |> gt(0) &&
+check_if_assays_are_NOT_overlapped <- function(se, dim = "cols") {
+    stopifnot(dim %in% c("rows", "cols"))
+    if (dim == "rows") {
+        namefcn <- rownames
+        dimfcn <- nrow
+    } else {
+        namefcn <- colnames
+        dimfcn <- ncol
+    }
     
-    # If I have more than one assay with colnames
-    Filter(
-      Negate(is.null),
-      assays(se, withDimnames = FALSE) |>  
+    # If I have any assay at all
+    assays(se) |> length() |> gt(0) &&
+        
+        # If I have at least one assay with dimnames
+        Filter(
+            Negate(is.null),
+            assays(se, withDimnames = FALSE) |>  
+                as.list() |> 
+                map(namefcn)
+        ) |> 
+        length() |>
+        gt(0) &&
+        
+        # If I have lack of consistency
+        # This will be TRUE also if some assays have dimnames and other don't
+        assays(se, withDimnames = FALSE) |>  
         as.list() |> 
-        map(colnames)
-    ) |> 
-    length() |>
-    gt(0) &&
-    
-    # If I have lack of consistency
-    assays(se, withDimnames = FALSE) |>  
-    as.list() |> 
-    map(colnames) |> 
-    reduce(intersect) |> 
-    length() |> 
-    equals(ncol(se)) |> 
-    not()
+        map(namefcn) |> 
+        reduce(intersect) |> 
+        length() |> 
+        equals(dimfcn(se)) |> 
+        not()
 }
 
 
-order_assays_internally_to_be_consistent = function(se){
-
-  se |> 
-    assays(withDimnames = FALSE) =
-      map2(
-        assays(se, withDimnames = FALSE) %>% as.list(),
-        names(assays(se)),
-        ~ {
-          
-          if(!is.null(rownames(se)) & !is.null(rownames(.x))) .x = .x[rownames(se),,drop=FALSE]
-          if(!is.null(colnames(se)) & !is.null(colnames(.x))) .x = .x[,colnames(se),drop=FALSE]
-          
-          .x
-          
-        })
-    
-    se
+order_assays_internally_to_be_consistent <- function(se) {
+    se <- check_se_dimnames(se)
+    se |> 
+        assays(withDimnames = FALSE) =
+            map2(
+                assays(se, withDimnames = FALSE) %>% as.list(),
+                names(assays(se)),
+                ~ {
+                    if (!is.null(rownames(se)) & !is.null(rownames(.x))) {
+                        .x = .x[rownames(se), , drop = FALSE]
+                    }
+                    if (!is.null(colnames(se)) & !is.null(colnames(.x))) {
+                        .x = .x[, colnames(se), drop = FALSE]
+                    }
+                    .x
+                    
+                })
+        
+        se
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1259,11 +1259,11 @@ check_if_assays_are_NOT_consistently_ordered <- function(se) {
 check_if_assays_are_NOT_overlapped <- function(se, dim = "cols") {
     stopifnot(dim %in% c("rows", "cols"))
     if (dim == "rows") {
-        namefcn <- rownames
-        dimfcn <- nrow
+        dimnames_function <- rownames
+        length_function <- nrow
     } else {
-        namefcn <- colnames
-        dimfcn <- ncol
+        dimnames_function <- colnames
+        length_function <- ncol
     }
     
     # If I have any assay at all
@@ -1274,7 +1274,7 @@ check_if_assays_are_NOT_overlapped <- function(se, dim = "cols") {
             Negate(is.null),
             assays(se, withDimnames = FALSE) |>  
                 as.list() |> 
-                map(namefcn)
+                map(dimnames_function)
         ) |> 
         length() |>
         gt(0) &&
@@ -1283,10 +1283,10 @@ check_if_assays_are_NOT_overlapped <- function(se, dim = "cols") {
         # This will be TRUE also if some assays have dimnames and other don't
         assays(se, withDimnames = FALSE) |>  
         as.list() |> 
-        map(namefcn) |> 
+        map(dimnames_function) |> 
         reduce(intersect) |> 
         length() |> 
-        equals(dimfcn(se)) |> 
+        equals(length_function(se)) |> 
         not()
 }
 

--- a/tests/testthat/test-dplyr_methods.R
+++ b/tests/testthat/test-dplyr_methods.R
@@ -160,11 +160,11 @@ test_that("mutate counts", {
     )
   
   se |> 
-  tidySummarizedExperiment:::check_if_assays_are_NOT_overlapped() |> 
+  tidySummarizedExperiment:::check_if_assays_are_NOT_overlapped(dim = "cols") |> 
     expect_equal(FALSE)
   
   se[,1] |> 
-    tidySummarizedExperiment:::check_if_assays_are_NOT_overlapped() |> 
+    tidySummarizedExperiment:::check_if_assays_are_NOT_overlapped(dim = "cols") |> 
     expect_equal(TRUE)
   
   })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -63,19 +63,46 @@ test_that("get_count_datasets works", {
     expect_equal(cds$mat2, seq(10, 18))
     expect_equal(cds$mat3, seq(19, 27))
     
-    # SE does not have dimnames, two assays have the same, third assay does not have -> error
+    # SE does not have dimnames, assays 1 and 3 have the same, assay 2 does not have
+    # SE dimnames will be set to those of assay 1, then assay 2 dimnames to those of the SE
     se1 <- se
     rownames(se1) <- colnames(se1) <- NULL
     rownames(assay(se1, "mat2", withDimnames = FALSE)) <- 
         colnames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
-    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names")
+    expect_warning(expect_warning(expect_warning(expect_warning(cds <- get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names"))))
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # SE does not have dimnames, assays 2 and 3 have the same, assay 1 does not have
+    # SE dimnames will be set to those of assay 2, then assay 1 dimnames to those of the SE
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    rownames(assay(se1, "mat1", withDimnames = FALSE)) <- 
+        colnames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    expect_warning(expect_warning(expect_warning(expect_warning(cds <- get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names"))))
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
     
     # SE does not have dimnames, assays have the same but in different order
     se1 <- se
     rownames(se1) <- colnames(se1) <- NULL
     colnames(assay(se1, "mat2", withDimnames = FALSE)) <- c("S2", "S3", "S1")
     rownames(assay(se1, "mat3", withDimnames = FALSE)) <- c("G2", "G3", "G1")
-    expect_warning(expect_warning(cds <- get_count_datasets(se1), "have column names, but the SummarizedExperiment does not"), "have row names, but the SummarizedExperiment does not")
+    expect_warning(expect_warning(cds <- get_count_datasets(se1)))
     expect_s3_class(cds, "tbl_df")
     expect_equal(nrow(cds), 9L)
     expect_equal(ncol(cds), 5L)
@@ -86,16 +113,38 @@ test_that("get_count_datasets works", {
     expect_equal(cds$mat2, c(16, 17, 18, 10, 11, 12, 13, 14, 15))
     expect_equal(cds$mat3, c(21, 19, 20, 24, 22, 23, 27, 25, 26))
     
-    # SE does not have dimnames, assays have nonoverlapping dimnames -> error
+    # SE does not have dimnames, assays have nonoverlapping dimnames
+    ## ...rownames
     se1 <- se
     rownames(se1) <- colnames(se1) <- NULL
     rownames(assay(se1, "mat2", withDimnames = FALSE)) <- paste0("A", seq_len(3))
-    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have row names")
+    expect_warning(expect_warning(expect_warning(cds <- get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have row names")))
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 18L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, c(rep(paste0("G", seq_len(3)), 3), 
+                                 rep(paste0("A", seq_len(3)), 3)))
+    expect_equal(cds$.sample, rep(rep(paste0("S", seq_len(3)), each = 3), 2))
+    expect_equal(cds$mat1, c(seq(1, 9), rep(NA, 9)))
+    expect_equal(cds$mat2, c(rep(NA, 9), seq(10, 18)))
+    expect_equal(cds$mat3, c(seq(19, 27), rep(NA, 9)))
     
+    ## ...colnames
     se1 <- se
     rownames(se1) <- colnames(se1) <- NULL
     colnames(assay(se1, "mat2", withDimnames = FALSE)) <- paste0("A", seq_len(3))
-    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names")
+    expect_warning(expect_warning(expect_warning(cds <- get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names")))
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 18L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(rep(paste0("G", seq_len(3)), 3), 2))
+    expect_equal(cds$.sample, c(rep(paste0("S", seq_len(3)), each = 3),
+                                rep(paste0("A", seq_len(3)), each = 3)))
+    expect_equal(cds$mat1, c(seq(1, 9), rep(NA, 9)))
+    expect_equal(cds$mat2, c(rep(NA, 9), seq(10, 18)))
+    expect_equal(cds$mat3, c(seq(19, 27), rep(NA, 9)))
     
     # Neither SE nor assays have column names
     se1 <- se
@@ -155,11 +204,29 @@ test_that("get_count_datasets works", {
     # SE has dimnames, assays have the same dimnames but not overlapping with those of the SE
     se1 <- se
     rownames(se1) <- colnames(se1) <- paste0("A", seq_len(3))
-    expect_error(get_count_datasets(se1), "don't agree with the column names of the SummarizedExperiment")
+    expect_warning(expect_warning(cds <- get_count_datasets(se1), "don't agree with the column names of the SummarizedExperiment"))
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
     
     se1 <- se
     rownames(se1) <- paste0("A", seq_len(3))
-    expect_error(get_count_datasets(se1), "don't agree with the row names of the SummarizedExperiment")
+    expect_warning(cds <- get_count_datasets(se1), "don't agree with the row names of the SummarizedExperiment")
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
     
     # SE has dimnames, none of the assays have
     se1 <- se

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1,0 +1,201 @@
+test_that("get_count_datasets works", {
+    # Use testthat edition 3
+    local_edition(3)
+    
+    # Generate test SE
+    se <- SummarizedExperiment::SummarizedExperiment(
+        assays = list(
+            mat1 = matrix(seq_len(9), nrow = 3),
+            mat2 = matrix(seq(10, 18), nrow = 3),
+            mat3 = matrix(seq(19, 27), nrow = 3)
+        )
+    )
+    rownames(se) <- paste0("G", seq_len(3))
+    colnames(se) <- paste0("S", seq_len(3))
+    SummarizedExperiment::assays(se) <- lapply(
+        SummarizedExperiment::assays(se),
+        function(x) {
+            rownames(x) <- rownames(se)
+            colnames(x) <- colnames(se)
+            x
+        }
+    )
+    
+    # Check that dimnames are as expected
+    expect_equal(rownames(se), rownames(assay(se, "mat1", withDimnames = FALSE)))
+    expect_equal(rownames(se), rownames(assay(se, "mat2", withDimnames = FALSE)))
+    expect_equal(rownames(se), rownames(assay(se, "mat3", withDimnames = FALSE)))
+    expect_equal(colnames(se), colnames(assay(se, "mat1", withDimnames = FALSE)))
+    expect_equal(colnames(se), colnames(assay(se, "mat2", withDimnames = FALSE)))
+    expect_equal(colnames(se), colnames(assay(se, "mat3", withDimnames = FALSE)))
+    # Check that matrix values are as expected
+    expect_equal(assay(se, "mat1")[, 1], c(1, 2, 3), ignore_attr = TRUE)
+    expect_equal(assay(se, "mat2")[, 2], c(13, 14, 15), ignore_attr = TRUE)
+    expect_equal(assay(se, "mat3")[, 3], c(25, 26, 27), ignore_attr = TRUE)
+    
+    # SE and all assays have the same dimnames
+    cds <- get_count_datasets(se)
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # SE does not have dimnames, all assays have the same
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    expect_equal(colnames(assay(se1, "mat1", withDimnames = FALSE)), paste0("S", seq_len(3)))
+    expect_equal(rownames(assay(se1, "mat1", withDimnames = FALSE)), paste0("G", seq_len(3)))
+    expect_null(colnames(se1))
+    expect_null(rownames(se1))
+    expect_warning(expect_warning(cds <- get_count_datasets(se1), "have column names, but the SummarizedExperiment does not"), "have row names, but the SummarizedExperiment does not")
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # SE does not have dimnames, two assays have the same, third assay does not have -> error
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    rownames(assay(se1, "mat2", withDimnames = FALSE)) <- 
+        colnames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names")
+    
+    # SE does not have dimnames, assays have the same but in different order
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    colnames(assay(se1, "mat2", withDimnames = FALSE)) <- c("S2", "S3", "S1")
+    rownames(assay(se1, "mat3", withDimnames = FALSE)) <- c("G2", "G3", "G1")
+    expect_warning(expect_warning(cds <- get_count_datasets(se1), "have column names, but the SummarizedExperiment does not"), "have row names, but the SummarizedExperiment does not")
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, c(16, 17, 18, 10, 11, 12, 13, 14, 15))
+    expect_equal(cds$mat3, c(21, 19, 20, 24, 22, 23, 27, 25, 26))
+    
+    # SE does not have dimnames, assays have nonoverlapping dimnames -> error
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    rownames(assay(se1, "mat2", withDimnames = FALSE)) <- paste0("A", seq_len(3))
+    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have row names")
+    
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- NULL
+    colnames(assay(se1, "mat2", withDimnames = FALSE)) <- paste0("A", seq_len(3))
+    expect_error(get_count_datasets(se1), "at least one of the assays in your SummarizedExperiment have column names")
+    
+    # Neither SE nor assays have column names
+    se1 <- se
+    colnames(se1) <- NULL
+    colnames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    cds <- get_count_datasets(se1)
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(as.character(seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # Neither SE nor assays have row names
+    se1 <- se
+    rownames(se1) <- NULL
+    rownames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    cds <- get_count_datasets(se1)
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(as.character(seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # Neither SE nor assays have any dimnames
+    se1 <- se
+    rownames(se1) <- NULL
+    colnames(se1) <- NULL
+    rownames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    cds <- get_count_datasets(se1)
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(as.character(seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(as.character(seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # SE has dimnames, assays have the same dimnames but not overlapping with those of the SE
+    se1 <- se
+    rownames(se1) <- colnames(se1) <- paste0("A", seq_len(3))
+    expect_error(get_count_datasets(se1), "don't agree with the column names of the SummarizedExperiment")
+    
+    se1 <- se
+    rownames(se1) <- paste0("A", seq_len(3))
+    expect_error(get_count_datasets(se1), "don't agree with the row names of the SummarizedExperiment")
+    
+    # SE has dimnames, none of the assays have
+    se1 <- se
+    rownames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat1", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat2", withDimnames = FALSE)) <- NULL
+    rownames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    colnames(assay(se1, "mat3", withDimnames = FALSE)) <- NULL
+    cds <- get_count_datasets(se1)
+    expect_s3_class(cds, "tbl_df")
+    expect_equal(nrow(cds), 9L)
+    expect_equal(ncol(cds), 5L)
+    expect_named(cds, c(".feature", ".sample", "mat1", "mat2", "mat3"))
+    expect_equal(cds$.feature, rep(paste0("G", seq_len(3)), 3))
+    expect_equal(cds$.sample, rep(paste0("S", seq_len(3)), each = 3))
+    expect_equal(cds$mat1, seq(1, 9))
+    expect_equal(cds$mat2, seq(10, 18))
+    expect_equal(cds$mat3, seq(19, 27))
+    
+    # Unnamed assay(s)
+    # se1 <- SummarizedExperiment::SummarizedExperiment(
+    #     assays = list(
+    #         matrix(seq_len(9), nrow = 3),
+    #         mat2 = matrix(seq(10, 18), nrow = 3),
+    #         matrix(seq(19, 27), nrow = 3)
+    #     )
+    # )
+    # expect_error(cds <- get_count_datasets(se1), "assays must be named")
+    # 
+    # se1 <- SummarizedExperiment::SummarizedExperiment(
+    #     assays = list(
+    #         matrix(seq_len(9), nrow = 3),
+    #         matrix(seq(10, 18), nrow = 3),
+    #         matrix(seq(19, 27), nrow = 3)
+    #     )
+    # )
+    # expect_error(cds <- get_count_datasets(se1), "assays must be named")
+})


### PR DESCRIPTION
Here's a first attempt to address https://github.com/stemangiola/tidySummarizedExperiment/issues/70, as well as increasing the consistency of `utilities.R` in terms of indentation, spaces and assignment operators.
Currently the situation where assays are unnamed is not handled well by `get_count_datasets()`. Do we want to require named assays? At the moment, adding a check for this makes `nest()` fail (even if the assays are in fact named). 